### PR TITLE
#8 accept keyword parameter metaclass from class definition

### DIFF
--- a/Lib/_abcoll.py
+++ b/Lib/_abcoll.py
@@ -30,8 +30,7 @@ def _hasattr(C, attr):
         return hasattr(C, attr)
 
 
-class Hashable:
-    __metaclass__ = ABCMeta
+class Hashable(metaclass=ABCMeta):
 
     @abstractmethod
     def __hash__(self):
@@ -53,8 +52,7 @@ class Hashable:
         return NotImplemented
 
 
-class Iterable:
-    __metaclass__ = ABCMeta
+class Iterable(metaclass=ABCMeta):
 
     @abstractmethod
     def __iter__(self):
@@ -88,8 +86,7 @@ class Iterator(Iterable):
         return NotImplemented
 
 
-class Sized:
-    __metaclass__ = ABCMeta
+class Sized(metaclass=ABCMeta):
 
     @abstractmethod
     def __len__(self):
@@ -103,8 +100,7 @@ class Sized:
         return NotImplemented
 
 
-class Container:
-    __metaclass__ = ABCMeta
+class Container(metaclass=ABCMeta):
 
     @abstractmethod
     def __contains__(self, x):
@@ -118,8 +114,7 @@ class Container:
         return NotImplemented
 
 
-class Callable:
-    __metaclass__ = ABCMeta
+class Callable(metaclass=ABCMeta):
 
     @abstractmethod
     def __call__(self, *args, **kwds):

--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -47,10 +47,10 @@ class _CData(object):
     def size(self):
         return self._jffi_type.size()
 
-class _ScalarCData(jffi.ScalarCData, _CData):
-    __metaclass__ = _CTypeMetaClass
+class _ScalarCData(jffi.ScalarCData, _CData, metaclass=_CTypeMetaClass):
+    pass
 
-    
+
 class _ArrayCData(object):
     def __len__(self):
         return self._jffi_type.length
@@ -130,11 +130,11 @@ class _UnionMetaClass(_AggregateMetaClass):
     def __new__(cls, name, bases, dict):
         return _AggregateMetaClass.__new_aggregate__(cls, name, bases, dict, union = True)
 
-class Structure(jffi.Structure, _CData):
-    __metaclass__ = _StructMetaClass
+class Structure(jffi.Structure, _CData, metaclass=_StructMetaClass):
+    pass
 
-class Union(jffi.Structure, _CData):
-    __metaclass__ = _UnionMetaClass
+class Union(jffi.Structure, _CData, metaclass=_UnionMetaClass):
+    pass
 
 def sizeof(type):
     if hasattr(type, '_jffi_type'):

--- a/Lib/io.py
+++ b/Lib/io.py
@@ -84,8 +84,8 @@ SEEK_END = 2
 # Declaring ABCs in C is tricky so we do it here.
 # Method descriptions and default implementations are inherited from the C
 # version however.
-class IOBase(_jyio._IOBase):
-    __metaclass__ = abc.ABCMeta
+class IOBase(_jyio._IOBase, metaclass=abc.ABCMeta):
+    pass
 
 class RawIOBase(_jyio._RawIOBase, IOBase):
     pass

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -122,8 +122,8 @@ class initarg(C):
 class metaclass(type):
     pass
 
-class use_metaclass(object):
-    __metaclass__ = metaclass
+class use_metaclass(object, metaclass=metaclass):
+    pass
 
 class pickling_metaclass(type):
     def __eq__(self, other):

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -26,8 +26,7 @@ class TestABC(unittest.TestCase):
         def bar(self): pass
         self.assertFalse(hasattr(bar, "__isabstractmethod__"))
 
-        class C:
-            __metaclass__ = abc.ABCMeta
+        class C(metaclass=abc.ABCMeta):
             @abc.abstractproperty
             def foo(self): return 3
         class D(C):
@@ -37,8 +36,7 @@ class TestABC(unittest.TestCase):
 
     def test_abstractmethod_integration(self):
         for abstractthing in [abc.abstractmethod, abc.abstractproperty]:
-            class C:
-                __metaclass__ = abc.ABCMeta
+            class C(metaclass=abc.ABCMeta):
                 @abstractthing
                 def foo(self): pass  # abstract
                 def bar(self): pass  # concrete
@@ -63,16 +61,16 @@ class TestABC(unittest.TestCase):
             self.assertTrue(isabstract(F))
 
     def test_subclass_oldstyle_class(self):
-        class A:
-            __metaclass__ = abc.ABCMeta
+        class A(metaclass=abc.ABCMeta):
+            pass
         class OldstyleClass:
             pass
         self.assertFalse(issubclass(OldstyleClass, A))
         self.assertFalse(issubclass(A, OldstyleClass))
 
     def test_isinstance_class(self):
-        class A:
-            __metaclass__ = abc.ABCMeta
+        class A(metaclass=abc.ABCMeta):
+            pass
         class OldstyleClass:
             pass
         self.assertFalse(isinstance(OldstyleClass, A))
@@ -82,8 +80,8 @@ class TestABC(unittest.TestCase):
         # self.assertTrue(isinstance(A, abc.ABCMeta))
 
     def test_registration_basics(self):
-        class A:
-            __metaclass__ = abc.ABCMeta
+        class A(metaclass=abc.ABCMeta):
+            pass
         class B(object):
             pass
         b = B()
@@ -105,8 +103,8 @@ class TestABC(unittest.TestCase):
         self.assertIsInstance(c, (A,))
 
     def test_isinstance_invalidation(self):
-        class A:
-            __metaclass__ = abc.ABCMeta
+        class A(metaclass=abc.ABCMeta):
+            pass
         class B(object):
             pass
         b = B()
@@ -117,8 +115,8 @@ class TestABC(unittest.TestCase):
         self.assertTrue(isinstance(b, (A,)))
 
     def test_registration_builtins(self):
-        class A:
-            __metaclass__ = abc.ABCMeta
+        class A(metaclass=abc.ABCMeta):
+            pass
         A.register(int)
         self.assertIsInstance(42, A)
         self.assertIsInstance(42, (A,))
@@ -133,8 +131,8 @@ class TestABC(unittest.TestCase):
         self.assertTrue(issubclass(str, (A,)))
 
     def test_registration_edge_cases(self):
-        class A:
-            __metaclass__ = abc.ABCMeta
+        class A(metaclass=abc.ABCMeta):
+            pass
         A.register(A)  # should pass silently
         class A1(A):
             pass
@@ -150,24 +148,24 @@ class TestABC(unittest.TestCase):
         C.register(B)  # ok
 
     def test_register_non_class(self):
-        class A(object):
-            __metaclass__ = abc.ABCMeta
+        class A(object, metaclass=abc.ABCMeta):
+            pass
         self.assertRaisesRegexp(TypeError, "Can only register classes",
                                 A.register, 4)
 
     def test_registration_transitiveness(self):
-        class A:
-            __metaclass__ = abc.ABCMeta
+        class A(metaclass=abc.ABCMeta):
+            pass
         self.assertTrue(issubclass(A, A))
         self.assertTrue(issubclass(A, (A,)))
-        class B:
-            __metaclass__ = abc.ABCMeta
+        class B(metaclass=abc.ABCMeta):
+            pass
         self.assertFalse(issubclass(A, B))
         self.assertFalse(issubclass(A, (B,)))
         self.assertFalse(issubclass(B, A))
         self.assertFalse(issubclass(B, (A,)))
-        class C:
-            __metaclass__ = abc.ABCMeta
+        class C(metaclass=abc.ABCMeta):
+            pass
         A.register(B)
         class B1(B):
             pass
@@ -195,8 +193,8 @@ class TestABC(unittest.TestCase):
         self.assertIsInstance(42, (A,))
 
     def test_all_new_methods_are_called(self):
-        class A:
-            __metaclass__ = abc.ABCMeta
+        class A(metaclass=abc.ABCMeta):
+            pass
         class B(object):
             counter = 0
             def __new__(cls):
@@ -211,8 +209,7 @@ class TestABC(unittest.TestCase):
     @test_support.cpython_only
     def test_cache_leak(self):
         # See issue #2521.
-        class A(object):
-            __metaclass__ = abc.ABCMeta
+        class A(object, metaclass=abc.ABCMeta):
             @abc.abstractmethod
             def f(self):
                 pass

--- a/Lib/test/test_class_jy.py
+++ b/Lib/test/test_class_jy.py
@@ -169,8 +169,8 @@ class ClassGeneralTestCase(unittest.TestCase):
             __slots__ = 'foo'
         # A regression up until 2.5a3: Defining Bar would cause a
         # TypeError "mro() returned base with unsuitable layout ('Bar')"
-        class Bar(SlottedBase):
-            __metaclass__ = Meta
+        class Bar(SlottedBase, metaclass=Meta):
+            pass
 
     def test_slotted_diamond_problem_bug(self):
         class A(object):
@@ -199,8 +199,8 @@ class ClassGeneralTestCase(unittest.TestCase):
             def __init__(cls, name, bases, attrs):
                 cls.counter += 1
 
-        class Base(object):
-            __metaclass__ = Meta
+        class Base(object, metaclass=Meta):
+            pass
         Foo = type('Foo', (Base,), {})
         # Previously we called the wrong __new__
         self.assertEqual(Foo.spam, 'Foo')
@@ -292,8 +292,7 @@ class ClassLocalsTestCase(unittest.TestCase):
         class SomeClass(object):
             pass
 
-        class MyFields(object):
-            __metaclass__ = FieldGathererMeta
+        class MyFields(object, metaclass=FieldGathererMeta):
             jython = 'foo'
             java = ('bar', SomeClass())
         # Technically SomeClass and FieldGathererMeta are actually
@@ -301,8 +300,7 @@ class ClassLocalsTestCase(unittest.TestCase):
         # them to be omitted from its class_dict
         self.assertEqual(MyFields.fields, ['JAVA', 'JYTHON'])
 
-        class MyFields2(object):
-            __metaclass__ = FieldGathererMeta
+        class MyFields2(object, metaclass=FieldGathererMeta):
             jython = 'foo'
             java = ('bar', SomeClass())
             locals()
@@ -372,16 +370,15 @@ class ClassMetaclassRepr(unittest.TestCase):
             def __new__(cls, name, bases, attrs):
                 return super(FooMetaclass, cls).__new__(cls, name, bases, attrs)
 
-        class Foo(object):
-            __metaclass__ = FooMetaclass
+        class Foo(object, metaclass=FooMetaclass):
+            pass
         self.assertEqual("<class '%s.Foo'>" % __name__, repr(Foo))
 
     def test_metaclass_str(self):
         class Foo(type):
             def __repr__(cls):
                 return 'foo'
-        class Bar(object):
-            __metaclass__ = Foo
+        class Bar(object, metaclass=Foo):
         self.assertEqual(repr(Bar), 'foo')
         # type.__str__ previously broke this
         self.assertEqual(str(Bar), 'foo')

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -440,8 +440,7 @@ class TestOneTrickPonyABCs(ABCTestCase):
 
     def test_registration(self):
         for B in Hashable, Iterable, Iterator, Sized, Container, Callable:
-            class C:
-                __metaclass__ = type
+            class C(metaclass=type):
                 __hash__ = None  # Make sure it isn't hashable by default
             self.assertFalse(issubclass(C, B), B.__name__)
             B.register(C)

--- a/Lib/test/test_copy.py
+++ b/Lib/test/test_copy.py
@@ -190,8 +190,8 @@ class TestCopy(unittest.TestCase):
         # type.
         class Meta(type):
             pass
-        class C:
-            __metaclass__ = Meta
+        class C(metaclass=Meta):
+            pass
         self.assertEqual(copy.deepcopy(C), C)
 
     def test_deepcopy_deepcopy(self):

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -666,8 +666,7 @@ def pylists():
 
 def metaclass():
     if verbose: print "Testing __metaclass__..."
-    class C:
-        __metaclass__ = type
+    class C(metaclass=type):
         def __init__(self):
             self.__state = 0
         def getstate(self):
@@ -688,8 +687,8 @@ def metaclass():
         def __new__(cls, name, bases, dict):
             dict['__spam__'] = 1
             return type.__new__(cls, name, bases, dict)
-    class C:
-        __metaclass__ = M1
+    class C(metaclass=M1):
+        pass
     vereq(C.__spam__, 1)
     c = C()
     vereq(c.__spam__, 1)
@@ -712,8 +711,7 @@ def metaclass():
                     continue
                 setattr(it, key, self.dict[key].__get__(it, self))
             return it
-    class C:
-        __metaclass__ = M2
+    class C(metaclass=M2):
         def spam(self):
             return 42
     vereq(C.name, 'C')
@@ -739,8 +737,7 @@ def metaclass():
                 name = "__super"
             setattr(cls, name, super(cls))
             return cls
-    class A:
-        __metaclass__ = autosuper
+    class A(metaclass=autosuper):
         def meth(self):
             return "A"
     class B(A):
@@ -778,8 +775,7 @@ def metaclass():
                 dict[key] = property(get, set)
             return super(autoproperty, metaclass).__new__(metaclass,
                                                         name, bases, dict)
-    class A:
-        __metaclass__ = autoproperty
+    class A(metaclass=autoproperty):
         def _get_x(self):
             return -self.__x
         def _set_x(self, x):
@@ -793,8 +789,7 @@ def metaclass():
     class multimetaclass(autoproperty, autosuper):
         # Merge of multiple cooperating metaclasses
         pass
-    class A:
-        __metaclass__ = multimetaclass
+    class A(metaclass=multimetaclass):
         def _get_x(self):
             return "A"
     class B(A):
@@ -813,8 +808,8 @@ def metaclass():
         counter = 0
         def __init__(self, *args):
             T.counter += 1
-    class C:
-        __metaclass__ = T
+    class C(metaclass=T):
+        pass
     vereq(T.counter, 1)
     a = C()
     vereq(type(a), C)
@@ -984,8 +979,8 @@ def multi():
     class Classic:
         pass
     try:
-        class New(Classic):
-            __metaclass__ = type
+        class New(Classic, metaclass=type):
+            pass
     except TypeError:
         pass
     else:
@@ -1457,8 +1452,8 @@ def dynamics():
     # Test comparison of classes with dynamic metaclasses
     class dynamicmetaclass(type):
         pass
-    class someclass:
-        __metaclass__ = dynamicmetaclass
+    class someclass(metaclass=dynamicmetaclass):
+        pass
     verify(someclass != object)
 
 def errors():
@@ -1689,36 +1684,39 @@ def altmro():
             L = type.mro(cls)
             L.reverse()
             return L
-    class X(D,B,C,A):
-        __metaclass__ = PerverseMetaType
+    class X(D,B,C,A, metaclass=PerverseMetaType):
+        pass
     vereq(X.__mro__, (object, A, C, B, D, X))
     vereq(X().f(), "A")
 
     try:
-        class X(object):
-            class __metaclass__(type):
-                def mro(self):
-                    return [self, dict, object]
+        class __metaclass__(type):
+            def mro(self):
+                return [self, dict, object]
+        class X(object, metaclass=__metaclass__):
+            pass
     except TypeError:
         pass
     else:
         raise TestFailed, "devious mro() return not caught"
 
     try:
-        class X(object):
-            class __metaclass__(type):
-                def mro(self):
-                    return [1]
+        class __metaclass__(type):
+            def mro(self):
+                return [1]
+        class X(object, metaclass=__metaclass__):
+            pass
     except TypeError:
         pass
     else:
         raise TestFailed, "non-class mro() return not caught"
 
     try:
-        class X(object):
-            class __metaclass__(type):
-                def mro(self):
-                    return 1
+        class __metaclass__(type):
+            def mro(self):
+                return 1
+        class X(object, metaclass=__metaclass__):
+            pass
     except TypeError:
         pass
     else:
@@ -2874,10 +2872,10 @@ def setdict():
         pass
     class Meta2(Base, type):
         pass
-    class D(object):
-        __metaclass__ = Meta1
-    class E(object):
-        __metaclass__ = Meta2
+    class D(object, metaclass=Meta1):
+        pass
+    class E(object, metaclass=Meta2):
+        pass
     for cls in C, D, E:
         verify_dict_readonly(cls)
         class_dict = cls.__dict__
@@ -3837,11 +3835,11 @@ def test_mutable_bases_with_failing_mro():
     class E(D):
         pass
 
-    class F(D):
-        __metaclass__ = WorkOnce
+    class F(D, metaclass=WorkOnce):
+        pass
 
-    class G(D):
-        __metaclass__ = WorkAlways
+    class G(D, metaclass=WorkAlways):
+        pass
 
     # Immediate subclasses have their mro's adjusted in alphabetical
     # order, so E's will get adjusted before adjusting F's fails.  We
@@ -3958,9 +3956,9 @@ def dict_type_with_metaclass():
         pass
     class M(type):
         pass
-    class C:
+    class C(metaclass=M):
         # In 2.3a1, C.__dict__ was a real dict rather than a dict proxy
-        __metaclass__ = M
+        pass
     veris(type(C.__dict__), type(B.__dict__))
 
 def meth_class_get():

--- a/Lib/test/test_descr_jy.py
+++ b/Lib/test/test_descr_jy.py
@@ -29,8 +29,8 @@ class TestDescrTestCase(unittest.TestCase):
                 self.assert_('foo' not in class_dict)
                 return cls
 
-        class Foo(object):
-            __metaclass__ = FooMeta
+        class Foo(object, metaclass=FooMeta):
+            pass
 
     def test_descr___get__(self):
         class Foo(object):

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -438,8 +438,7 @@ class ExceptionTests(unittest.TestCase):
             def __subclasscheck__(cls, subclass):
                 raise ValueError()
 
-        class MyException(Exception):
-            __metaclass__ = Meta
+        class MyException(Exception, metaclass=Meta):
             pass
 
         with captured_output("stderr") as stderr:

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -129,8 +129,7 @@ class TestPredicates(IsTestBase):
     def test_isabstract(self):
         from abc import ABCMeta, abstractmethod
 
-        class AbstractClassExample(object):
-            __metaclass__ = ABCMeta
+        class AbstractClassExample(object, metaclass=ABCMeta):
 
             @abstractmethod
             def foo(self):

--- a/Lib/test/test_java_subclasses.py
+++ b/Lib/test/test_java_subclasses.py
@@ -349,8 +349,8 @@ class MetaClass(type):
         return super(MetaClass, meta).__new__(meta, name, bases, d)
 
 
-class MetaBase(object):
-    __metaclass__ = MetaClass
+class MetaBase(object, metaclass=MetaClass):
+    pass
 
 
 class MetaClassTest(unittest.TestCase):

--- a/Lib/test/test_metaclass_support/simpleclass.py
+++ b/Lib/test/test_metaclass_support/simpleclass.py
@@ -1,3 +1,3 @@
 from metaclass import NoOpMetaClass
-class TestClass(object):
-    __metaclass__ = NoOpMetaClass
+class TestClass(object, metaclass=NoOpMetaClass):
+    pass

--- a/src/org/python/core/Py.java
+++ b/src/org/python/core/Py.java
@@ -1827,21 +1827,24 @@ public final class Py {
 
     // XXX: The following two makeClass overrides are *only* for the
     // old compiler, they should be removed when the newcompiler hits
-    public static PyObject makeClass(String name, PyObject[] bases, PyCode code) {
-        return makeClass(name, bases, code, null);
+    public static PyObject makeClass(String name, PyObject[] bases, PyObject metaclass, PyCode code) {
+        return makeClass(name, bases, metaclass, code, null);
     }
 
-    public static PyObject makeClass(String name, PyObject[] bases, PyCode code,
+    public static PyObject makeClass(String name, PyObject[] bases, PyObject metaclass, PyCode code,
                                      PyObject[] closure_cells) {
         ThreadState state = getThreadState();
         PyObject dict = code.call(state, Py.EmptyObjects, Py.NoKeywords,
                 state.frame.f_globals, Py.EmptyObjects, new PyTuple(closure_cells));
-        return makeClass(name, bases, dict);
+        return makeClass(name, bases, dict, metaclass);
+    }
+    public static PyObject makeClass(String name, PyObject base, PyObject dict) {
+        return makeClass(name, base, dict, null);
     }
 
-    public static PyObject makeClass(String name, PyObject base, PyObject dict) {
+    public static PyObject makeClass(String name, PyObject base, PyObject dict, PyObject metaclass) {
         PyObject[] bases = base == null ? EmptyObjects : new PyObject[] {base};
-        return makeClass(name, bases, dict);
+        return makeClass(name, bases, dict, metaclass);
     }
 
     /**
@@ -1854,8 +1857,10 @@ public final class Py {
      * @return a new Python Class PyObject
      */
     public static PyObject makeClass(String name, PyObject[] bases, PyObject dict) {
-        PyObject metaclass = dict.__finditem__("__metaclass__");
+        return makeClass(name, bases, dict, null);
+    }
 
+    public static PyObject makeClass(String name, PyObject[] bases, PyObject dict, PyObject metaclass) {
         if (metaclass == null) {
             if (bases.length != 0) {
                 PyObject base = bases[0];


### PR DESCRIPTION
According to http://www.diveintopython3.net/porting-code-to-python-3-with-2to3.html#metaclass, `__metaclass__` class attribute is no longer supported.