### PR TITLE
PEP-0448 Additional Unpacking Generalizations

### DIFF
--- a/Lib/xml/dom/domreg.py
+++ b/Lib/xml/dom/domreg.py
@@ -87,7 +87,7 @@ def _parse_feature_string(s):
     while i < length:
         feature = parts[i]
         if feature[0] in "0123456789":
-            raise ValueError, "bad feature name: " + `feature`
+            raise ValueError, "bad feature name: " + repr(feature)
         i = i + 1
         version = None
         if i < length:

--- a/Lib/xml/dom/minidom.py
+++ b/Lib/xml/dom/minidom.py
@@ -628,9 +628,9 @@ class TypeInfo(NewStyle):
 
     def __repr__(self):
         if self.namespace:
-            return "<TypeInfo %s (from %s)>" % (`self.name`, `self.namespace`)
+            return "<TypeInfo %s (from %s)>" % (repr(self.name), repr(self.namespace))
         else:
-            return "<TypeInfo %s>" % `self.name`
+            return "<TypeInfo %s>" % repr(self.name)
 
     def _get_name(self):
         return self.name

--- a/Lib/xml/dom/xmlbuilder.py
+++ b/Lib/xml/dom/xmlbuilder.py
@@ -81,7 +81,7 @@ class DOMBuilder:
                 settings = self._settings[(_name_xform(name), state)]
             except KeyError:
                 raise xml.dom.NotSupportedErr(
-                    "unsupported feature: " + `name`)
+                    "unsupported feature: " + repr(name))
             else:
                 for name, value in settings:
                     setattr(self._options, name, value)

--- a/ast/Python.asdl
+++ b/ast/Python.asdl
@@ -74,8 +74,7 @@ module Python version "$Revision$"
          -- need sequences for compare to distinguish between
          -- x < 4 < 3 and (x < 4) < 3
          | Compare(expr left, cmpop* ops, expr* comparators)
-         | Call(expr func, expr* args, keyword* keywords,
-             expr? starargs, expr? kwargs)
+         | Call(expr func, expr* args, keyword* keywords)
          | Repr(expr value)
          | Num(object n) -- a number as a PyObject.
          | Str(string s) -- need to specify raw, unicode, etc?
@@ -114,11 +113,11 @@ module Python version "$Revision$"
     excepthandler = ExceptHandler(expr? type, expr? name, stmt* body)
                     attributes (int lineno, int col_offset)
 
-    arguments = (expr* args, identifier? vararg,
-             identifier? kwarg, expr* defaults)
+    arguments = (expr* args, identifier? vararg, identifier* kwonlyargs, expr* kw_defaults,
+                 identifier? kwarg, expr* defaults)
 
-    -- keyword arguments supplied to call
-    keyword = (identifier arg, expr value)
+    -- keyword arguments supplied to call (NULL identifier for **kwargs)
+    keyword = (identifier? arg, expr value)
 
     -- import name with optional 'as' alias.
     alias = (identifier name, identifier? asname)

--- a/ast/asdl_antlr.py
+++ b/ast/asdl_antlr.py
@@ -899,6 +899,7 @@ indexer_support = {"Attribute": """    // Support for indexer below
     // method signature to avoid clashes with the (Token, List<expr>,
     // String, String, List<expr>) version of the constructor.
     public arguments(Token token, java.util.List<expr> args, Name vararg, Name kwarg,
+                     java.util.List<Name> kwonlyargs, java.util.List<expr> kw_defaults,
             java.util.List<expr> defaults) {
         super(token);
         this.args = args;
@@ -912,6 +913,20 @@ indexer_support = {"Attribute": """    // Support for indexer below
         this.varargName = vararg;
         this.kwarg = kwarg == null ? null : kwarg.getText();
         this.kwargName = kwarg;
+
+        this.kwonlyargs = new ArrayList<>();
+        if (kwonlyargs != null) {
+            for (Name arg : kwonlyargs) {
+                this.kwonlyargs.add(arg.getText());
+            }
+        }
+        this.kw_defaults = kw_defaults;
+        if (kw_defaults == null) {
+            this.kw_defaults = new ArrayList<expr>();
+        }
+        for(PythonTree t : this.kw_defaults) {
+            addChild(t);
+        }
         this.defaults = defaults;
         if (defaults == null) {
             this.defaults = new ArrayList<expr>();

--- a/ast/build.xml
+++ b/ast/build.xml
@@ -10,7 +10,7 @@
     <target name="asdl_gen">
         <apply
             verbose="true"
-            executable="python">
+            executable="python2">
             <arg value="./asdl_antlr.py" />
             <fileset dir="." includes="Python.asdl"/>
         </apply>

--- a/grammar/Python.g
+++ b/grammar/Python.g
@@ -522,7 +522,8 @@ parameters
         }
       |
         {
-            $args = new arguments($parameters.start, new ArrayList<expr>(), (Name)null, null, new ArrayList<expr>());
+            $args = new arguments($parameters.start, new ArrayList<expr>(), (Name)null, null,
+            new ArrayList<Name>(), new ArrayList<expr>(), new ArrayList<expr>());
         }
       )
       RPAREN
@@ -539,8 +540,8 @@ tdefparameter
           $etype = actions.castExpr($tfpdef.tree);
           if ($ASSIGN != null) {
               defaults.add($test.tree);
-          } else if (!defaults.isEmpty()) {
-              throw new ParseException("non-default argument follows default argument", $tfpdef.tree);
+          } else {
+              defaults.add(null);
           }
       }
     ;
@@ -556,8 +557,8 @@ vdefparameter
           $etype = actions.castExpr($vfpdef.tree);
           if ($ASSIGN != null) {
               defaults.add($test.tree);
-          } else if (!defaults.isEmpty()) {
-              throw new ParseException("non-default argument follows default argument", $vfpdef.tree);
+          } else {
+              defaults.add(null);
           }
       }
     ;
@@ -571,28 +572,28 @@ typedargslist
     returns [arguments args]
 @init {
     List defaults = new ArrayList();
+    List kw_defaults = new ArrayList();
 }
     : d+=tdefparameter[defaults] (options {greedy=true;}:COMMA d+=tdefparameter[defaults])*
       (COMMA
-          (STAR (starargs=NAME)? (COMMA d+=tdefparameter[defaults] (options {greedy=true;}:COMMA d+=tdefparameter[defaults])*)? (COMMA DOUBLESTAR kwargs=NAME)?
+          (STAR (starargs=NAME)? (COMMA kw+=tdefparameter[kw_defaults] (options {greedy=true;}:COMMA kw+=tdefparameter[kw_defaults])*)? (COMMA DOUBLESTAR kwargs=NAME)?
           | DOUBLESTAR kwargs=NAME
           )?
       )?
       {
-          $args = actions.makeArgumentsType($typedargslist.start, $d, $starargs, $kwargs, defaults);
+          $args = actions.makeArgumentsType($typedargslist.start, $d, $starargs, $kwargs, $kw, kw_defaults, defaults);
       }
-    | STAR (starargs=NAME)? (COMMA d+=tdefparameter[defaults] (options {greedy=true;}:COMMA d+=tdefparameter[defaults])*)? (COMMA DOUBLESTAR kwargs=NAME)?
+    | STAR (starargs=NAME)? (COMMA kw+=tdefparameter[kw_defaults] (options {greedy=true;}:COMMA kw+=tdefparameter[kw_defaults])*)? (COMMA DOUBLESTAR kwargs=NAME)?
       {
-          $args = actions.makeArgumentsType($typedargslist.start, $d, $starargs, $kwargs, defaults);
+          $args = actions.makeArgumentsType($typedargslist.start, $d, $starargs, $kwargs, $kw, kw_defaults, defaults);
       }
     | DOUBLESTAR kwargs=NAME
       {
-          $args = actions.makeArgumentsType($typedargslist.start, $d, null, $kwargs, defaults);
+          $args = actions.makeArgumentsType($typedargslist.start, $d, null, $kwargs, $kw, kw_defaults, defaults);
       }
     ;
 
 //tfpdef: NAME [':' test]
-//FIXME: remove fplist
 tfpdef[expr_contextType ctype]
 @init {
     expr etype = null;
@@ -607,11 +608,6 @@ tfpdef[expr_contextType ctype]
       {
           etype = new Name($NAME, $NAME.text, ctype);
       }
-    | (LPAREN tfpdef[null] COMMA) => LPAREN fplist RPAREN
-      {
-          etype = new Tuple($fplist.start, actions.castExprs($fplist.etypes), expr_contextType.Store);
-      }
-    | LPAREN! fplist RPAREN!
     ;
 
 //fplist: vfpdef (',' vfpdef)* [',']
@@ -624,30 +620,35 @@ fplist
       }
     ;
 
-//varargslist: ((vfpdef ['=' test] ',')*
-//              ('*' NAME [',' '**' NAME] | '**' NAME) |
-//              vfpdef ['=' test] (',' vfpdef ['=' test])* [','])
+//varargslist: (vfpdef ['=' test] (',' vfpdef ['=' test])* [',' [
+//        '*' [vfpdef] (',' vfpdef ['=' test])* [',' ['**' vfpdef [',']]]
+//      | '**' vfpdef [',']]]
+//  | '*' [vfpdef] (',' vfpdef ['=' test])* [',' ['**' vfpdef [',']]]
+//  | '**' vfpdef [',']
+//)
 varargslist
     returns [arguments args]
 @init {
     List defaults = new ArrayList();
+    List kw_defaults = new ArrayList();
 }
     : d+=vdefparameter[defaults] (options {greedy=true;}:COMMA d+=vdefparameter[defaults])*
       (COMMA
-          (STAR starargs=NAME (COMMA DOUBLESTAR kwargs=NAME)?
+          (STAR (starargs=NAME)? (COMMA kw+=vdefparameter[kw_defaults] (options {greedy=true;}:COMMA kw+=vdefparameter[kw_defaults])*)? (COMMA DOUBLESTAR kwargs=NAME)?
           | DOUBLESTAR kwargs=NAME
           )?
       )?
       {
-          $args = actions.makeArgumentsType($varargslist.start, $d, $starargs, $kwargs, defaults);
+          $args = actions.makeArgumentsType($varargslist.start, $d, $starargs, $kwargs, $kw,
+          kw_defaults, defaults);
       }
-    | STAR starargs=NAME (COMMA DOUBLESTAR kwargs=NAME)?
+    | STAR (starargs=NAME)? (COMMA kw+=vdefparameter[kw_defaults] (options {greedy=true;}:COMMA kw+=vdefparameter[kw_defaults])*)? (COMMA DOUBLESTAR kwargs=NAME)?
       {
-          $args = actions.makeArgumentsType($varargslist.start, $d, $starargs, $kwargs, defaults);
+          $args = actions.makeArgumentsType($varargslist.start, $d, $starargs, $kwargs, $kw, kw_defaults, defaults);
       }
     | DOUBLESTAR kwargs=NAME
       {
-          $args = actions.makeArgumentsType($varargslist.start, $d, null, $kwargs, defaults);
+          $args = actions.makeArgumentsType($varargslist.start, $d, null, $kwargs, $kw, kw_defaults, defaults);
       }
     ;
 
@@ -2025,7 +2026,8 @@ lambdef
       {
           arguments a = $varargslist.args;
           if (a == null) {
-              a = new arguments($LAMBDA, new ArrayList<expr>(), (Name)null, null, new ArrayList<expr>());
+              a = new arguments($LAMBDA, new ArrayList<expr>(), (Name)null, null,
+              new ArrayList<Name>(), new ArrayList<expr>(), new ArrayList<expr>());
           }
           etype = new Lambda($LAMBDA, a, actions.castExpr($test.tree));
       }
@@ -2043,7 +2045,7 @@ lambdef_nocond
       {
           arguments a = $varargslist.args;
           if (a == null) {
-              a = new arguments($LAMBDA, new ArrayList<expr>(), (Name)null, null, new ArrayList<expr>());
+              a = new arguments($LAMBDA, new ArrayList<expr>(), (Name)null, null, new ArrayList<Name>(), new ArrayList<expr>(), new ArrayList<expr>());
           }
           etype = new Lambda($LAMBDA, a, actions.castExpr($test_nocond.tree));
       }

--- a/grammar/Python.g
+++ b/grammar/Python.g
@@ -465,8 +465,7 @@ decorator
     ( LPAREN
       ( arglist
         {
-            $etype = actions.makeCall($LPAREN, $dotted_attr.etype, $arglist.args, $arglist.keywords,
-                     $arglist.starargs, $arglist.kwargs);
+            $etype = actions.makeCall($LPAREN, $dotted_attr.etype, $arglist.args, $arglist.keywords);
         }
       |
         {
@@ -563,10 +562,11 @@ vdefparameter
       }
     ;
 
-
-//typedargslist: ((tfpdef ['=' test] ',')*
-//              ('*' NAME [',' '**' NAME] | '**' NAME) |
-//              tfpdef ['=' test] (',' tfpdef ['=' test])* [','])
+//typedargslist: (tfpdef ['=' test] (',' tfpdef ['=' test])* [',' [
+//        '*' [tfpdef] (',' tfpdef ['=' test])* [',' ['**' tfpdef [',']]]
+//      | '**' tfpdef [',']]]
+//  | '*' [tfpdef] (',' tfpdef ['=' test])* [',' ['**' tfpdef [',']]]
+//  | '**' tfpdef [','])
 typedargslist
     returns [arguments args]
 @init {
@@ -623,7 +623,6 @@ fplist
           $etypes = $f;
       }
     ;
-
 
 //varargslist: ((vfpdef ['=' test] ',')*
 //              ('*' NAME [',' '**' NAME] | '**' NAME) |
@@ -707,9 +706,7 @@ small_stmt : expr_stmt
            | import_stmt
            | global_stmt
            | nonlocal_stmt
-           | exec_stmt
            | assert_stmt
-           | {!printFunction}? => print_stmt
            ;
 
 //star_expr: '*' expr
@@ -1445,6 +1442,28 @@ test[expr_contextType ctype]
     | lambdef
     ;
 
+//test_nocond: or_test | lambdef_nocond
+test_nocond[expr_contextType ctype]
+@init {
+    expr etype = null;
+}
+@after {
+   if (etype != null) {
+       $test_nocond.tree = etype;
+   }
+}
+    : o1=or_test[ctype]
+      ( (IF or_test[null] ORELSE) => IF o2=or_test[ctype] ORELSE e=test[expr_contextType.Load]
+         {
+             etype = new IfExp($o1.start, actions.castExpr($o2.tree), actions.castExpr($o1.tree), actions.castExpr($e.tree));
+         }
+      |
+     -> or_test
+      )
+    | lambdef_nocond
+    ;
+
+
 //or_test: and_test ('or' and_test)*
 or_test
     [expr_contextType ctype] returns [Token leftTok]
@@ -1904,9 +1923,9 @@ atom
         }
        )
        RCURLY
-     | lb=BACKQUOTE testlist[expr_contextType.Load] rb=BACKQUOTE
+     | NAME_CONSTANT
        {
-           etype = new Repr($lb, actions.castExpr($testlist.tree));
+           etype = new NameConstant($NAME_CONSTANT.tree);
        }
      | name_or_print
        {
@@ -2012,6 +2031,25 @@ lambdef
       }
     ;
 
+//lambdef_nocond: 'lambda' [varargslist] ':' test_nocond
+lambdef_nocond
+@init {
+    expr etype = null;
+}
+@after {
+    $lambdef_nocond.tree = etype;
+}
+    : LAMBDA (varargslist)? COLON test_nocond[expr_contextType.Load]
+      {
+          arguments a = $varargslist.args;
+          if (a == null) {
+              a = new arguments($LAMBDA, new ArrayList<expr>(), (Name)null, null, new ArrayList<expr>());
+          }
+          etype = new Lambda($LAMBDA, a, actions.castExpr($test_nocond.tree));
+      }
+    ;
+
+
 //trailer: '(' [arglist] ')' | '[' subscriptlist ']' | '.' NAME
 trailer [Token begin, PythonTree ptree]
 @init {
@@ -2026,11 +2064,11 @@ trailer [Token begin, PythonTree ptree]
       (arglist
        {
            etype = new Call($begin, actions.castExpr($ptree), actions.castExprs($arglist.args),
-             actions.makeKeywords($arglist.keywords), $arglist.starargs, $arglist.kwargs);
+             actions.makeKeywords($arglist.keywords));
        }
       |
        {
-           etype = new Call($begin, actions.castExpr($ptree), new ArrayList<expr>(), new ArrayList<keyword>(), null, null);
+           etype = new Call($begin, actions.castExpr($ptree), new ArrayList<expr>(), new ArrayList<keyword>());
        }
       )
       RPAREN
@@ -2141,8 +2179,10 @@ testlist[expr_contextType ctype]
     | test[ctype]
     ;
 
-//dictorsetmaker: ( (test ':' test (comp_for | (',' test ':' test)* [','])) |
-//                  (test (comp_for | (',' test)* [','])) )
+//dictorsetmaker: ( ((test ':' test | '**' expr)
+//                   (comp_for | (',' (test ':' test | '**' expr))* [','])) |
+//                  ((test | star_expr)
+//                   (comp_for | (',' (test | star_expr))* [','])) )
 dictorsetmaker[Token lcurly]
 @init {
     List gens = new ArrayList();
@@ -2153,27 +2193,20 @@ dictorsetmaker[Token lcurly]
         $dictorsetmaker.tree = etype;
     }
 }
-    : k+=test[expr_contextType.Load]
-         (
-             (COLON v+=test[expr_contextType.Load]
-               ( comp_for[gens]
-                 {
-                     Collections.reverse(gens);
-                     List<comprehension> c = gens;
-                     etype = new DictComp($dictorsetmaker.start, actions.castExpr($k.get(0)), actions.castExpr($v.get(0)), c);
-                 }
-               | (options {k=2;}:COMMA k+=test[expr_contextType.Load] COLON v+=test[expr_contextType.Load])*
-                 {
-                     etype = new Dict($lcurly, actions.castExprs($k), actions.castExprs($v));
-                 }
-               )
-             |(COMMA k+=test[expr_contextType.Load])*
-              {
-                  etype = new Set($lcurly, actions.castExprs($k));
-              }
-             )
-             (COMMA)?
-         | comp_for[gens]
+    : (test[expr_contextType.Load] COLON | DOUBLESTAR) => (k+=test[expr_contextType.Load] COLON v+=test[expr_contextType.Load] | DOUBLESTAR uv+=expr[expr_contextType.Load])
+         ( comp_for[gens]
+           {
+              Collections.reverse(gens);
+              List<comprehension> c = gens;
+              etype = new DictComp($dictorsetmaker.start, actions.castExpr($k.get(0)), actions.castExpr($v.get(0)), c);
+           }
+         | (options {k=2;}:COMMA (k+=test[expr_contextType.Load] COLON v+=test[expr_contextType.Load] | DOUBLESTAR uv+=expr[expr_contextType.Load]))*
+           {
+              etype = new Dict($lcurly, actions.castExprs($k), actions.castExprs($v, $uv));
+           }
+         (COMMA)?)
+    | (k+=test[expr_contextType.Load] | s+=star_expr[expr_contextType.Load])
+         ( comp_for[gens]
            {
                Collections.reverse(gens);
                List<comprehension> c = gens;
@@ -2183,7 +2216,11 @@ dictorsetmaker[Token lcurly]
                }
                etype = new SetComp($lcurly, actions.castExpr($k.get(0)), c);
            }
-         )
+         | (COMMA (k+=test[expr_contextType.Load] | s+=star_expr[expr_contextType.Load]))*
+           {
+               etype = new Set($lcurly, actions.castExprs($k, $s));
+           }
+         (COMMA)?)
     ;
 
 //classdef: 'class' NAME ['(' [arglist] ')'] ':' suite
@@ -2203,93 +2240,84 @@ classdef
           stype = actions.makeClass(t, $NAME,
                                     $arglist.args,
                                     $arglist.keywords,
-                                    $arglist.starargs,
-                                    $arglist.kwargs,
                                     $suite.stypes,
                                     $decorators.etypes);
       }
     ;
 
 //arglist: (argument ',')* (argument [',']
-//                         |'*' test (',' argument)* [',' '**' test]
-//                         |'**' test)
 arglist
-    returns [List args, List keywords, expr starargs, expr kwargs]
+    returns [List args, List keywords]
 @init {
-    List arguments = new ArrayList();
-    List kws = new ArrayList();
+    List args = new ArrayList();
+    List keywords = new ArrayList();
     List gens = new ArrayList();
+    boolean first = true;
 }
-    : argument[arguments, kws, gens, true, false] (COMMA argument[arguments, kws, gens, false, false])*
-          (COMMA
-              ( STAR s=test[expr_contextType.Load] (COMMA argument[arguments, kws, gens, false, true])* (COMMA DOUBLESTAR k=test[expr_contextType.Load])?
-              | DOUBLESTAR k=test[expr_contextType.Load]
-              )?
-          )?
+    : argument[args, keywords, gens, first] (COMMA argument[args, keywords, gens, first])* COMMA?
       {
-          if (arguments.size() > 1 && gens.size() > 0) {
-              actions.errorGenExpNotSoleArg(new PythonTree($arglist.start));
-          }
-          $args=arguments;
-          $keywords=kws;
-          $starargs=actions.castExpr($s.tree);
-          $kwargs=actions.castExpr($k.tree);
-      }
-    | STAR s=test[expr_contextType.Load] (COMMA argument[arguments, kws, gens, false, true])* (COMMA DOUBLESTAR k=test[expr_contextType.Load])?
-      {
-          $starargs=actions.castExpr($s.tree);
-          $keywords=kws;
-          $kwargs=actions.castExpr($k.tree);
-      }
-    | DOUBLESTAR k=test[expr_contextType.Load]
-      {
-          $kwargs=actions.castExpr($k.tree);
+        $args = args;
+        $keywords = keywords;
       }
     ;
 
-//argument: test [comp_for] | test '=' test  # Really [keyword '='] test
+//argument: ( test [comp_for] |
+//            test '=' test |
+//            '**' test |
+//            '*' test )
 argument
-    [List arguments, List kws, List gens, boolean first, boolean afterStar] returns [boolean genarg]
+    [List args, List keywords, List gens, boolean first] returns [boolean genarg]
     : t1=test[expr_contextType.Load]
-        ((ASSIGN t2=test[expr_contextType.Load])
-          {
-              expr newkey = actions.castExpr($t1.tree);
-              //Loop through all current keys and fail on duplicate.
-              for(Object o: $kws) {
-                  List list = (List)o;
-                  Object oldkey = list.get(0);
-                  if (oldkey instanceof Name && newkey instanceof Name) {
-                      if (((Name)oldkey).getId().equals(((Name)newkey).getId())) {
-                          errorHandler.error("keyword arguments repeated", $t1.tree);
-                      }
-                  }
-              }
-              List<expr> exprs = new ArrayList<expr>();
-              exprs.add(newkey);
-              exprs.add(actions.castExpr($t2.tree));
-              $kws.add(exprs);
-          }
-        | comp_for[$gens]
-          {
-              if (!first) {
-                  actions.errorGenExpNotSoleArg($comp_for.tree);
-              }
-              $genarg = true;
-              Collections.reverse($gens);
-              List<comprehension> c = $gens;
-              arguments.add(new GeneratorExp($t1.start, actions.castExpr($t1.tree), c));
-          }
-        |
-          {
-              if (kws.size() > 0) {
-                  errorHandler.error("non-keyword arg after keyword arg", $t1.tree);
-              } else if (afterStar) {
-                  errorHandler.error("only named arguments may follow *expression", $t1.tree);
-              }
-              $arguments.add($t1.tree);
-          }
-        )
+      ( comp_for[$gens]
+        {
+            if (!first) {
+                actions.errorGenExpNotSoleArg($comp_for.tree);
+            }
+            $first = false;
+            $genarg = true;
+            Collections.reverse($gens);
+            List<comprehension> c = $gens;
+            $args.add(new GeneratorExp($t1.start, actions.castExpr($t1.tree), c));
+        }
+      | ASSIGN t2=test[expr_contextType.Load]
+        {
+            expr newkey = actions.castExpr($t1.tree);
+            //Loop through all current keys and fail on duplicate.
+            for(Object o: $keywords) {
+                List list = (List)o;
+                Object oldkey = list.get(0);
+                if (oldkey instanceof Name && newkey instanceof Name) {
+                    if (((Name)oldkey).getId().equals(((Name)newkey).getId())) {
+                        errorHandler.error("keyword arguments repeated", $t1.tree);
+                    }
+                }
+            }
+            List<expr> exprs = new ArrayList<expr>();
+            exprs.add(newkey);
+            exprs.add(actions.castExpr($t2.tree));
+            $keywords.add(exprs);
+
+        }
+      |
+        {
+            $args.add($t1.tree);
+        }
+      )
+    | STAR s=test[expr_contextType.Load]
+        {
+            expr etype = new Starred($STAR, actions.castExpr($s.tree), expr_contextType.Load);
+            $args.add(etype);
+        }
+
+    | DOUBLESTAR k=test[expr_contextType.Load]
+      {
+          List<expr> exprs = new ArrayList<>();
+          exprs.add(null);
+          exprs.add(actions.castExpr($k.tree));
+          $keywords.add(exprs);
+      }
     ;
+
 
 //list_iter: list_for | list_if
 list_iter [List gens, List ifs]
@@ -2335,11 +2363,11 @@ comp_for [List gens]
       }
     ;
 
-//comp_if: 'if' old_test [comp_iter]
+//comp_if: 'if' test_nocond [comp_iter]
 comp_if[List gens, List ifs]
-    : IF test[expr_contextType.Load] comp_iter[gens, ifs]?
+    : IF test_nocond[expr_contextType.Load] comp_iter[gens, ifs]?
       {
-        ifs.add(actions.castExpr($test.tree));
+        ifs.add(actions.castExpr($test_nocond.tree));
       }
     ;
 

--- a/src/org/python/antlr/GrammarActions.java
+++ b/src/org/python/antlr/GrammarActions.java
@@ -187,6 +187,16 @@ public class GrammarActions {
         return result;
     }
 
+    List<expr> castExprs(List exprs1, List exprs2) {
+        List exprs = exprs1;
+        if (exprs == null) {
+            exprs = exprs2;
+        } else if (exprs2 != null) {
+            exprs.addAll(exprs2);
+        }
+        return castExprs(exprs);
+    }
+
     List<stmt> makeElse(List elseSuite, PythonTree elif) {
         if (elseSuite != null) {
             return castStmts(elseSuite);
@@ -384,8 +394,10 @@ public class GrammarActions {
                 Object v = e.get(1);
                 checkAssign(castExpr(k));
                 if (k instanceof Name) {
-                    Name arg = (Name)k;
+                    Name arg = (Name) k;
                     keywords.add(new keyword(arg, arg.getInternalId(), castExpr(v)));
+                } else if (k == null) {
+                    keywords.add(new keyword(null, castExpr(v)));
                 } else {
                     errorHandler.error("keyword must be a name", (PythonTree)k);
                 }
@@ -547,13 +559,21 @@ public class GrammarActions {
         return makeCall(t, func, null, null, null, null);
     }
 
-    expr makeCall(Token t, expr func, List args, List keywords, expr starargs, expr kwargs) {
+    expr makeCall(Token t, expr func, List args, List keywords) {
         if (func == null) {
             return errorHandler.errorExpr(new PythonTree(t));
         }
         List<keyword> k = makeKeywords(keywords);
         List<expr> a = castExprs(args);
-        return new Call(t, func, a, k, starargs, kwargs);
+        return new Call(t, func, a, k);
+    }
+
+    expr makeCall(Token t, expr func, List args, List keywords, expr starargs, expr kwargs) {
+        return makeCall(t, func, args, keywords);
+    }
+
+    stmt makeClass(Token t, Token nameToken, List args, List ktypes, List stypes, List dtypes) {
+      return makeClass(t, nameToken, args, ktypes, null, null, stypes, dtypes);
     }
 
     stmt makeClass(Token t, Token nameToken, List args, List ktypes, expr starargs, expr kwargs, List stypes, List dtypes) {

--- a/src/org/python/antlr/GrammarActions.java
+++ b/src/org/python/antlr/GrammarActions.java
@@ -310,7 +310,9 @@ public class GrammarActions {
         if (args != null) {
             a = args;
         } else {
-            a = new arguments(t, new ArrayList<expr>(), (Name)null, null, new ArrayList<expr>());
+            a = new arguments(t, new ArrayList<expr>(), (Name)null, null,
+                    // kwonlyargs, kw_defaults, defaults
+                    new ArrayList<Name>(), new ArrayList<expr>(), new ArrayList<expr>());
         }
         List<stmt> s = castStmts(funcStatements);
         List<expr> d = castExprs(decorators);
@@ -362,9 +364,10 @@ public class GrammarActions {
     }
 
     arguments makeArgumentsType(Token t, List params, Token snameToken,
-        Token knameToken, List defaults) {
+        Token knameToken, List kwonlyargs, List<expr> kwDefaults, List defaults) {
 
         List<expr> p = castExprs(params);
+        List<expr> kwd = kwDefaults; // Note: castExprs remove the null elements, don't do that
         List<expr> d = castExprs(defaults);
         Name s;
         Name k;
@@ -378,7 +381,7 @@ public class GrammarActions {
         } else {
             k = cantBeNoneName(knameToken);
         }
-        return new arguments(t, p, s, k, d);
+        return new arguments(t, p, s, k, kwonlyargs, kwd, d);
     }
 
     List<expr> extractArgs(List args) {

--- a/src/org/python/antlr/ast/Call.java
+++ b/src/org/python/antlr/ast/Call.java
@@ -69,36 +69,9 @@ public static final PyType TYPE = PyType.fromClass(Call.class);
         this.keywords = AstAdapters.py2keywordList(keywords);
     }
 
-    private expr starargs;
-    public expr getInternalStarargs() {
-        return starargs;
-    }
-    @ExposedGet(name = "starargs")
-    public PyObject getStarargs() {
-        return starargs;
-    }
-    @ExposedSet(name = "starargs")
-    public void setStarargs(PyObject starargs) {
-        this.starargs = AstAdapters.py2expr(starargs);
-    }
-
-    private expr kwargs;
-    public expr getInternalKwargs() {
-        return kwargs;
-    }
-    @ExposedGet(name = "kwargs")
-    public PyObject getKwargs() {
-        return kwargs;
-    }
-    @ExposedSet(name = "kwargs")
-    public void setKwargs(PyObject kwargs) {
-        this.kwargs = AstAdapters.py2expr(kwargs);
-    }
-
 
     private final static PyString[] fields =
-    new PyString[] {new PyString("func"), new PyString("args"), new PyString("keywords"), new
-                     PyString("starargs"), new PyString("kwargs")};
+    new PyString[] {new PyString("func"), new PyString("args"), new PyString("keywords")};
     @ExposedGet(name = "_fields")
     public PyString[] get_fields() { return fields; }
 
@@ -117,35 +90,30 @@ public static final PyType TYPE = PyType.fromClass(Call.class);
     @ExposedMethod
     public void Call___init__(PyObject[] args, String[] keywords) {
         ArgParser ap = new ArgParser("Call", args, keywords, new String[]
-            {"func", "args", "keywords", "starargs", "kwargs", "lineno", "col_offset"}, 5, true);
+            {"func", "args", "keywords", "lineno", "col_offset"}, 3, true);
         setFunc(ap.getPyObject(0, Py.None));
         setArgs(ap.getPyObject(1, Py.None));
         setKeywords(ap.getPyObject(2, Py.None));
-        setStarargs(ap.getPyObject(3, Py.None));
-        setKwargs(ap.getPyObject(4, Py.None));
-        int lin = ap.getInt(5, -1);
+        int lin = ap.getInt(3, -1);
         if (lin != -1) {
             setLineno(lin);
         }
 
-        int col = ap.getInt(6, -1);
+        int col = ap.getInt(4, -1);
         if (col != -1) {
             setLineno(col);
         }
 
     }
 
-    public Call(PyObject func, PyObject args, PyObject keywords, PyObject starargs, PyObject
-    kwargs) {
+    public Call(PyObject func, PyObject args, PyObject keywords) {
         setFunc(func);
         setArgs(args);
         setKeywords(keywords);
-        setStarargs(starargs);
-        setKwargs(kwargs);
     }
 
     public Call(Token token, expr func, java.util.List<expr> args, java.util.List<keyword>
-    keywords, expr starargs, expr kwargs) {
+    keywords) {
         super(token);
         this.func = func;
         addChild(func);
@@ -163,14 +131,10 @@ public static final PyType TYPE = PyType.fromClass(Call.class);
         for(PythonTree t : this.keywords) {
             addChild(t);
         }
-        this.starargs = starargs;
-        addChild(starargs);
-        this.kwargs = kwargs;
-        addChild(kwargs);
     }
 
     public Call(Integer ttype, Token token, expr func, java.util.List<expr> args,
-    java.util.List<keyword> keywords, expr starargs, expr kwargs) {
+    java.util.List<keyword> keywords) {
         super(ttype, token);
         this.func = func;
         addChild(func);
@@ -188,14 +152,10 @@ public static final PyType TYPE = PyType.fromClass(Call.class);
         for(PythonTree t : this.keywords) {
             addChild(t);
         }
-        this.starargs = starargs;
-        addChild(starargs);
-        this.kwargs = kwargs;
-        addChild(kwargs);
     }
 
     public Call(PythonTree tree, expr func, java.util.List<expr> args, java.util.List<keyword>
-    keywords, expr starargs, expr kwargs) {
+    keywords) {
         super(tree);
         this.func = func;
         addChild(func);
@@ -213,10 +173,6 @@ public static final PyType TYPE = PyType.fromClass(Call.class);
         for(PythonTree t : this.keywords) {
             addChild(t);
         }
-        this.starargs = starargs;
-        addChild(starargs);
-        this.kwargs = kwargs;
-        addChild(kwargs);
     }
 
     @ExposedGet(name = "repr")
@@ -234,12 +190,6 @@ public static final PyType TYPE = PyType.fromClass(Call.class);
         sb.append(",");
         sb.append("keywords=");
         sb.append(dumpThis(keywords));
-        sb.append(",");
-        sb.append("starargs=");
-        sb.append(dumpThis(starargs));
-        sb.append(",");
-        sb.append("kwargs=");
-        sb.append(dumpThis(kwargs));
         sb.append(",");
         sb.append(")");
         return sb.toString();
@@ -264,10 +214,6 @@ public static final PyType TYPE = PyType.fromClass(Call.class);
                     t.accept(visitor);
             }
         }
-        if (starargs != null)
-            starargs.accept(visitor);
-        if (kwargs != null)
-            kwargs.accept(visitor);
     }
 
     public PyObject __dict__;

--- a/src/org/python/antlr/ast/arguments.java
+++ b/src/org/python/antlr/ast/arguments.java
@@ -57,6 +57,32 @@ public class arguments extends PythonTree {
         this.vararg = AstAdapters.py2identifier(vararg);
     }
 
+    private java.util.List<String> kwonlyargs;
+    public java.util.List<String> getInternalKwonlyargs() {
+        return kwonlyargs;
+    }
+    @ExposedGet(name = "kwonlyargs")
+    public PyObject getKwonlyargs() {
+        return new AstList(kwonlyargs, AstAdapters.identifierAdapter);
+    }
+    @ExposedSet(name = "kwonlyargs")
+    public void setKwonlyargs(PyObject kwonlyargs) {
+        this.kwonlyargs = AstAdapters.py2identifierList(kwonlyargs);
+    }
+
+    private java.util.List<expr> kw_defaults;
+    public java.util.List<expr> getInternalKw_defaults() {
+        return kw_defaults;
+    }
+    @ExposedGet(name = "kw_defaults")
+    public PyObject getKw_defaults() {
+        return new AstList(kw_defaults, AstAdapters.exprAdapter);
+    }
+    @ExposedSet(name = "kw_defaults")
+    public void setKw_defaults(PyObject kw_defaults) {
+        this.kw_defaults = AstAdapters.py2exprList(kw_defaults);
+    }
+
     private String kwarg;
     public String getInternalKwarg() {
         return kwarg;
@@ -86,8 +112,8 @@ public class arguments extends PythonTree {
 
 
     private final static PyString[] fields =
-    new PyString[] {new PyString("args"), new PyString("vararg"), new PyString("kwarg"), new
-                     PyString("defaults")};
+    new PyString[] {new PyString("args"), new PyString("vararg"), new PyString("kwonlyargs"), new
+                     PyString("kw_defaults"), new PyString("kwarg"), new PyString("defaults")};
     @ExposedGet(name = "_fields")
     public PyString[] get_fields() { return fields; }
 
@@ -105,22 +131,27 @@ public class arguments extends PythonTree {
     @ExposedMethod
     public void arguments___init__(PyObject[] args, String[] keywords) {
         ArgParser ap = new ArgParser("arguments", args, keywords, new String[]
-            {"args", "vararg", "kwarg", "defaults"}, 4, true);
+            {"args", "vararg", "kwonlyargs", "kw_defaults", "kwarg", "defaults"}, 6, true);
         setArgs(ap.getPyObject(0, Py.None));
         setVararg(ap.getPyObject(1, Py.None));
-        setKwarg(ap.getPyObject(2, Py.None));
-        setDefaults(ap.getPyObject(3, Py.None));
+        setKwonlyargs(ap.getPyObject(2, Py.None));
+        setKw_defaults(ap.getPyObject(3, Py.None));
+        setKwarg(ap.getPyObject(4, Py.None));
+        setDefaults(ap.getPyObject(5, Py.None));
     }
 
-    public arguments(PyObject args, PyObject vararg, PyObject kwarg, PyObject defaults) {
+    public arguments(PyObject args, PyObject vararg, PyObject kwonlyargs, PyObject kw_defaults,
+    PyObject kwarg, PyObject defaults) {
         setArgs(args);
         setVararg(vararg);
+        setKwonlyargs(kwonlyargs);
+        setKw_defaults(kw_defaults);
         setKwarg(kwarg);
         setDefaults(defaults);
     }
 
-    public arguments(Token token, java.util.List<expr> args, String vararg, String kwarg,
-    java.util.List<expr> defaults) {
+    public arguments(Token token, java.util.List<expr> args, String vararg, java.util.List<String>
+    kwonlyargs, java.util.List<expr> kw_defaults, String kwarg, java.util.List<expr> defaults) {
         super(token);
         this.args = args;
         if (args == null) {
@@ -130,6 +161,14 @@ public class arguments extends PythonTree {
             addChild(t);
         }
         this.vararg = vararg;
+        this.kwonlyargs = kwonlyargs;
+        this.kw_defaults = kw_defaults;
+        if (kw_defaults == null) {
+            this.kw_defaults = new ArrayList<expr>();
+        }
+        for(PythonTree t : this.kw_defaults) {
+            addChild(t);
+        }
         this.kwarg = kwarg;
         this.defaults = defaults;
         if (defaults == null) {
@@ -140,8 +179,9 @@ public class arguments extends PythonTree {
         }
     }
 
-    public arguments(Integer ttype, Token token, java.util.List<expr> args, String vararg, String
-    kwarg, java.util.List<expr> defaults) {
+    public arguments(Integer ttype, Token token, java.util.List<expr> args, String vararg,
+    java.util.List<String> kwonlyargs, java.util.List<expr> kw_defaults, String kwarg,
+    java.util.List<expr> defaults) {
         super(ttype, token);
         this.args = args;
         if (args == null) {
@@ -151,6 +191,14 @@ public class arguments extends PythonTree {
             addChild(t);
         }
         this.vararg = vararg;
+        this.kwonlyargs = kwonlyargs;
+        this.kw_defaults = kw_defaults;
+        if (kw_defaults == null) {
+            this.kw_defaults = new ArrayList<expr>();
+        }
+        for(PythonTree t : this.kw_defaults) {
+            addChild(t);
+        }
         this.kwarg = kwarg;
         this.defaults = defaults;
         if (defaults == null) {
@@ -161,7 +209,8 @@ public class arguments extends PythonTree {
         }
     }
 
-    public arguments(PythonTree tree, java.util.List<expr> args, String vararg, String kwarg,
+    public arguments(PythonTree tree, java.util.List<expr> args, String vararg,
+    java.util.List<String> kwonlyargs, java.util.List<expr> kw_defaults, String kwarg,
     java.util.List<expr> defaults) {
         super(tree);
         this.args = args;
@@ -172,6 +221,14 @@ public class arguments extends PythonTree {
             addChild(t);
         }
         this.vararg = vararg;
+        this.kwonlyargs = kwonlyargs;
+        this.kw_defaults = kw_defaults;
+        if (kw_defaults == null) {
+            this.kw_defaults = new ArrayList<expr>();
+        }
+        for(PythonTree t : this.kw_defaults) {
+            addChild(t);
+        }
         this.kwarg = kwarg;
         this.defaults = defaults;
         if (defaults == null) {
@@ -195,6 +252,12 @@ public class arguments extends PythonTree {
         sb.append("vararg=");
         sb.append(dumpThis(vararg));
         sb.append(",");
+        sb.append("kwonlyargs=");
+        sb.append(dumpThis(kwonlyargs));
+        sb.append(",");
+        sb.append("kw_defaults=");
+        sb.append(dumpThis(kw_defaults));
+        sb.append(",");
         sb.append("kwarg=");
         sb.append(dumpThis(kwarg));
         sb.append(",");
@@ -213,6 +276,12 @@ public class arguments extends PythonTree {
     public void traverse(VisitorIF<?> visitor) throws Exception {
         if (args != null) {
             for (PythonTree t : args) {
+                if (t != null)
+                    t.accept(visitor);
+            }
+        }
+        if (kw_defaults != null) {
+            for (PythonTree t : kw_defaults) {
                 if (t != null)
                     t.accept(visitor);
             }

--- a/src/org/python/antlr/ast/arguments.java
+++ b/src/org/python/antlr/ast/arguments.java
@@ -327,6 +327,7 @@ public class arguments extends PythonTree {
     // method signature to avoid clashes with the (Token, List<expr>,
     // String, String, List<expr>) version of the constructor.
     public arguments(Token token, java.util.List<expr> args, Name vararg, Name kwarg,
+                     java.util.List<Name> kwonlyargs, java.util.List<expr> kw_defaults,
             java.util.List<expr> defaults) {
         super(token);
         this.args = args;
@@ -340,6 +341,20 @@ public class arguments extends PythonTree {
         this.varargName = vararg;
         this.kwarg = kwarg == null ? null : kwarg.getText();
         this.kwargName = kwarg;
+
+        this.kwonlyargs = new ArrayList<>();
+        if (kwonlyargs != null) {
+            for (Name arg : kwonlyargs) {
+                this.kwonlyargs.add(arg.getText());
+            }
+        }
+        this.kw_defaults = kw_defaults;
+        if (kw_defaults == null) {
+            this.kw_defaults = new ArrayList<expr>();
+        }
+        for(PythonTree t : this.kw_defaults) {
+            addChild(t);
+        }
         this.defaults = defaults;
         if (defaults == null) {
             this.defaults = new ArrayList<expr>();

--- a/src/org/python/compiler/CodeCompiler.java
+++ b/src/org/python/compiler/CodeCompiler.java
@@ -500,6 +500,8 @@ public class CodeCompiler extends Visitor implements Opcodes, ClassConstants {
         // NOTE: this is attached to the constructed PyFunction, so it cannot be nulled out
         // with freeArray, unlike other usages of makeArray here
         int defaults = makeArray(scope.ac.getDefaults());
+        int kwDefaultKeys = makeStrings(code, scope.ac.kw_defaults.keySet());
+        int kwDefaultValues = makeArray(new ArrayList<>(scope.ac.kw_defaults.values()));
 
         code.new_(p(PyFunction.class));
         code.dup();
@@ -507,6 +509,15 @@ public class CodeCompiler extends Visitor implements Opcodes, ClassConstants {
         code.getfield(p(PyFrame.class), "f_globals", ci(PyObject.class));
         code.aload(defaults);
         code.freeLocal(defaults);
+
+        code.new_(p(PyDictionary.class));
+        code.dup();
+        code.aload(kwDefaultKeys);
+        code.aload(kwDefaultValues);
+        code.invokespecial(p(PyDictionary.class), "<init>",
+                sig(Void.TYPE, String[].class, PyObject[].class));
+        code.freeLocal(kwDefaultKeys);
+        code.freeLocal(kwDefaultValues);
 
         scope.setup_closure();
         scope.dump();
@@ -522,12 +533,12 @@ public class CodeCompiler extends Visitor implements Opcodes, ClassConstants {
 
         if (!makeClosure(scope)) {
             code.invokespecial(p(PyFunction.class), "<init>",
-                    sig(Void.TYPE, PyObject.class, PyObject[].class, PyCode.class, PyObject.class));
+                    sig(Void.TYPE, PyObject.class, PyObject[].class, PyDictionary.class, PyCode.class, PyObject.class));
         } else {
             code.invokespecial(
                     p(PyFunction.class),
                     "<init>",
-                    sig(Void.TYPE, PyObject.class, PyObject[].class, PyCode.class, PyObject.class,
+                    sig(Void.TYPE, PyObject.class, PyObject[].class, PyDictionary.class, PyCode.class, PyObject.class,
                             PyObject[].class));
         }
 
@@ -2365,6 +2376,8 @@ public class CodeCompiler extends Visitor implements Opcodes, ClassConstants {
         ScopeInfo scope = module.getScopeInfo(node);
 
         int defaultsArray = makeArray(scope.ac.getDefaults());
+        int kwDefaultKeys = makeStrings(code, scope.ac.kw_defaults.keySet());
+        int kwDefaultValues = makeArray(new ArrayList<>(scope.ac.kw_defaults.values()));
 
         code.new_(p(PyFunction.class));
 
@@ -2374,8 +2387,16 @@ public class CodeCompiler extends Visitor implements Opcodes, ClassConstants {
 
         loadFrame();
         code.getfield(p(PyFrame.class), "f_globals", ci(PyObject.class));
-
         code.swap();
+
+        code.new_(p(PyDictionary.class));
+        code.dup();
+        code.aload(kwDefaultKeys);
+        code.aload(kwDefaultValues);
+        code.invokespecial(p(PyDictionary.class), "<init>",
+                sig(Void.TYPE, String[].class, PyObject[].class));
+        code.freeLocal(kwDefaultKeys);
+        code.freeLocal(kwDefaultValues);
 
         scope.setup_closure();
         scope.dump();
@@ -2384,12 +2405,12 @@ public class CodeCompiler extends Visitor implements Opcodes, ClassConstants {
 
         if (!makeClosure(scope)) {
             code.invokespecial(p(PyFunction.class), "<init>",
-                    sig(Void.TYPE, PyObject.class, PyObject[].class, PyCode.class));
+                    sig(Void.TYPE, PyObject.class, PyObject[].class, PyDictionary.class, PyCode.class));
         } else {
             code.invokespecial(
                     p(PyFunction.class),
                     "<init>",
-                    sig(Void.TYPE, PyObject.class, PyObject[].class, PyCode.class, PyObject[].class));
+                    sig(Void.TYPE, PyObject.class, PyObject[].class, PyDictionary.class, PyCode.class, PyObject[].class));
         }
         return null;
     }
@@ -2652,6 +2673,11 @@ public class CodeCompiler extends Visitor implements Opcodes, ClassConstants {
 
         int emptyArray = makeArray(new ArrayList<expr>());
         code.aload(emptyArray);
+        code.new_(p(PyDictionary.class));
+        code.dup();
+        code.invokespecial(p(PyDictionary.class), "<init>",
+                sig(Void.TYPE));
+
         scope.setup_closure();
         scope.dump();
 
@@ -2686,12 +2712,12 @@ public class CodeCompiler extends Visitor implements Opcodes, ClassConstants {
         code.aconst_null();
         if (!makeClosure(scope)) {
             code.invokespecial(p(PyFunction.class), "<init>",
-                    sig(Void.TYPE, PyObject.class, PyObject[].class, PyCode.class, PyObject.class));
+                    sig(Void.TYPE, PyObject.class, PyObject[].class, PyDictionary.class, PyCode.class, PyObject.class));
         } else {
             code.invokespecial(
                     p(PyFunction.class),
                     "<init>",
-                    sig(Void.TYPE, PyObject.class, PyObject[].class, PyCode.class, PyObject.class,
+                    sig(Void.TYPE, PyObject.class, PyObject[].class, PyDictionary.class, PyCode.class, PyObject.class,
                             PyObject[].class));
         }
         int genExp = storeTop();
@@ -2725,6 +2751,12 @@ public class CodeCompiler extends Visitor implements Opcodes, ClassConstants {
 
         int emptyArray = makeArray(new ArrayList<expr>());
         code.aload(emptyArray);
+
+        code.new_(p(PyDictionary.class));
+        code.dup();
+        code.invokespecial(p(PyDictionary.class), "<init>",
+                sig(Void.TYPE));
+
         scope.setup_closure();
         scope.dump();
 
@@ -2759,12 +2791,12 @@ public class CodeCompiler extends Visitor implements Opcodes, ClassConstants {
         code.aconst_null();
         if (!makeClosure(scope)) {
             code.invokespecial(p(PyFunction.class), "<init>",
-                    sig(Void.TYPE, PyObject.class, PyObject[].class, PyCode.class, PyObject.class));
+                    sig(Void.TYPE, PyObject.class, PyObject[].class, PyDictionary.class, PyCode.class, PyObject.class));
         } else {
             code.invokespecial(
                     p(PyFunction.class),
                     "<init>",
-                    sig(Void.TYPE, PyObject.class, PyObject[].class, PyCode.class, PyObject.class,
+                    sig(Void.TYPE, PyObject.class, PyObject[].class, PyDictionary.class, PyCode.class, PyObject.class,
                             PyObject[].class));
         }
         int genExp = storeTop();

--- a/src/org/python/compiler/CodeCompiler.java
+++ b/src/org/python/compiler/CodeCompiler.java
@@ -1816,53 +1816,54 @@ public class CodeCompiler extends Visitor implements Opcodes, ClassConstants {
 
     @Override
     public Object visitCall(Call node) throws Exception {
+        java.util.List<expr> starargs = new ArrayList<>();
+        java.util.List<expr> kwargs = new ArrayList<>();
         java.util.List<String> keys = new ArrayList<String>();
         java.util.List<expr> values = new ArrayList<expr>();
         for (int i = 0; i < node.getInternalArgs().size(); i++) {
-            values.add(node.getInternalArgs().get(i));
-        }
-        for (int i = 0; i < node.getInternalKeywords().size(); i++) {
-            keys.add(node.getInternalKeywords().get(i).getInternalArg());
-            values.add(node.getInternalKeywords().get(i).getInternalValue());
+            expr arg = node.getInternalArgs().get(i);
+            if (arg instanceof Starred) {
+                starargs.add(arg);
+            } else {
+                values.add(arg);
+            }
         }
 
-        if ((node.getInternalKeywords() == null || node.getInternalKeywords().size() == 0)
-                && node.getInternalStarargs() == null && node.getInternalKwargs() == null
-                && node.getInternalFunc() instanceof Attribute) {
+        for (int i = 0; i < node.getInternalKeywords().size(); i++) {
+            String key = node.getInternalKeywords().get(i).getInternalArg();
+            expr value = node.getInternalKeywords().get(i).getInternalValue();
+            if (key == null) {
+                kwargs.add(value);
+            } else {
+                keys.add(key);
+                values.add(value);
+            }
+        }
+
+        if (node.getInternalFunc() instanceof Attribute
+                && keys.isEmpty() && starargs.isEmpty() && kwargs.isEmpty()) {
             return invokeNoKeywords((Attribute)node.getInternalFunc(), values);
         }
 
         visit(node.getInternalFunc());
         stackProduce();
 
-        if (node.getInternalStarargs() != null || node.getInternalKwargs() != null) {
+        if (!starargs.isEmpty() || !kwargs.isEmpty()) {
             int argArray = makeArray(values);
             int strArray = makeStrings(code, keys);
-            if (node.getInternalStarargs() == null) {
-                code.aconst_null();
-            } else {
-                visit(node.getInternalStarargs());
-            }
-            stackProduce();
-            if (node.getInternalKwargs() == null) {
-                code.aconst_null();
-            } else {
-                visit(node.getInternalKwargs());
-            }
-            stackProduce();
-
+            int starargArray = makeArray(starargs);
+            int kwArray = makeArray(kwargs);
             code.aload(argArray);
             code.aload(strArray);
+            code.aload(starargArray);
+            code.aload(kwArray);
             code.freeLocal(strArray);
-            code.dup2_x2();
-            code.pop2();
-
-            stackConsume(3); // target + starargs + kwargs
+            stackConsume(); // target
             code.invokevirtual(
                     p(PyObject.class),
                     "_callextra",
-                    sig(PyObject.class, PyObject[].class, String[].class, PyObject.class,
-                            PyObject.class));
+                    sig(PyObject.class, PyObject[].class, String[].class, PyObject[].class,
+                            PyObject[].class));
             freeArrayRef(argArray);
         } else if (keys.size() > 0) {
             loadThreadState();
@@ -2246,8 +2247,8 @@ public class CodeCompiler extends Visitor implements Opcodes, ClassConstants {
             java.util.List<comprehension> generators, String tmp_append) throws Exception {
         set(new Name(node, tmp_append, expr_contextType.Store));
 
-        stmt n = new Expr(node, new Call(node, new Name(node, tmp_append, expr_contextType.Load), //
-                args, new ArrayList<keyword>(), null, null));
+        stmt n = new Expr(node, new Call(node, new Name(node, tmp_append, expr_contextType.Load),
+                args, new ArrayList<keyword>()));
 
         for (int i = generators.size() - 1; i >= 0; i--) {
             comprehension lc = generators.get(i);
@@ -2271,9 +2272,11 @@ public class CodeCompiler extends Visitor implements Opcodes, ClassConstants {
     @Override
     public Object visitDict(Dict node) throws Exception {
         java.util.List<PythonTree> elts = new ArrayList<PythonTree>();
-        for (int i = 0; i < node.getInternalKeys().size(); i++) {
-            elts.add(node.getInternalKeys().get(i));
-            elts.add(node.getInternalValues().get(i));
+        java.util.List<expr> keys = node.getInternalKeys();
+        java.util.List<expr> vals = node.getInternalValues();
+        for (int i = 0; i < keys.size(); i++) {
+            elts.add(keys.get(i));
+            elts.add(vals.get(i));
         }
 
         if (my_scope.generator) {
@@ -2289,13 +2292,30 @@ public class CodeCompiler extends Visitor implements Opcodes, ClassConstants {
             loadArray(code, elts);
             code.invokespecial(p(PyDictionary.class), "<init>", sig(Void.TYPE, PyObject[].class));
         }
+        if (vals.size() > keys.size()) {
+            for (int i = keys.size(); i < vals.size(); i++) {
+                code.dup();
+                visit(vals.get(i));
+                code.invokevirtual(p(PyDictionary.class), "merge", sig(Void.TYPE, PyObject.class));
+            }
+        }
         return null;
     }
 
     @Override
     public Object visitSet(Set node) throws Exception {
+        java.util.List<expr> elts = node.getInternalElts();
+        java.util.List<expr> stars = new ArrayList<>();
+        java.util.List<expr> scalars = new ArrayList<>();
+        for (expr e : elts) {
+            if (e instanceof Starred) {
+                stars.add(e);
+            } else {
+                scalars.add(e);
+            }
+        }
         if (my_scope.generator) {
-            int content = makeArray(node.getInternalElts());
+            int content = makeArray(scalars);
             code.new_(p(PySet.class));
             code.dup();
             code.aload(content);
@@ -2304,8 +2324,13 @@ public class CodeCompiler extends Visitor implements Opcodes, ClassConstants {
         } else {
             code.new_(p(PySet.class));
             code.dup();
-            loadArray(code, node.getInternalElts());
+            loadArray(code, scalars);
             code.invokespecial(p(PySet.class), "<init>", sig(Void.TYPE, PyObject[].class));
+        }
+        for (expr e : stars) {
+            code.dup();
+            visit(e);
+            code.invokevirtual(p(PySet.class), "_update", sig(Void.TYPE, PyObject.class));
         }
         return null;
     }

--- a/src/org/python/compiler/Module.java
+++ b/src/org/python/compiler/Module.java
@@ -249,6 +249,7 @@ class PyCodeConstant extends Constant implements ClassConstants, Opcodes {
 
     final String co_name;
     final int argcount;
+    final int kwonlyargcount;
     final List<String> names;
     final int id;
     final int co_firstlineno;
@@ -274,7 +275,8 @@ class PyCodeConstant extends Constant implements ClassConstants, Opcodes {
         if (scope.ac != null) {
             arglist = scope.ac.arglist;
             keywordlist = scope.ac.keywordlist;
-            argcount = scope.ac.names.size();
+            kwonlyargcount = scope.ac.kwonlyargcount;
+            argcount = scope.ac.names.size() - kwonlyargcount;
 
             // Do something to add init_code to tree
             // XXX: not sure we should be modifying scope.ac in a PyCodeConstant
@@ -286,6 +288,7 @@ class PyCodeConstant extends Constant implements ClassConstants, Opcodes {
             arglist = false;
             keywordlist = false;
             argcount = 0;
+            kwonlyargcount = 0;
         }
 
         id = module.codes.size();
@@ -401,7 +404,7 @@ class PyCodeConstant extends Constant implements ClassConstants, Opcodes {
         }
 
         c.iconst(jy_npurecell);
-
+        c.iconst(kwonlyargcount);
         c.iconst(moreflags);
 
         c.invokestatic(
@@ -409,7 +412,7 @@ class PyCodeConstant extends Constant implements ClassConstants, Opcodes {
                 "newCode",
                 sig(PyCode.class, Integer.TYPE, String[].class, String.class, String.class,
                         Integer.TYPE, Boolean.TYPE, Boolean.TYPE, PyFunctionTable.class,
-                        Integer.TYPE, String[].class, String[].class, Integer.TYPE, Integer.TYPE));
+                        Integer.TYPE, String[].class, String[].class, Integer.TYPE, Integer.TYPE, Integer.TYPE));
         c.putstatic(module.classfile.name, name, ci(PyCode.class));
     }
 }

--- a/src/org/python/compiler/ScopesCompiler.java
+++ b/src/org/python/compiler/ScopesCompiler.java
@@ -334,7 +334,12 @@ public class ScopesCompiler extends Visitor implements ScopeConstants {
         ArgListCompiler ac = new ArgListCompiler();
         List<expr> args = new ArrayList<expr>();
         args.add(new Name(node.getToken(), bound_exp, expr_contextType.Param));
-        ac.visitArgs(new arguments(node, args, null, null, new ArrayList<expr>()));
+        String vararg = null;
+        List<String> kwonlyargs = new ArrayList<>();
+        List<expr> kw_defaults = new ArrayList<>();
+        String kwarg = null;
+        List<expr> defaults = new ArrayList<>();
+        ac.visitArgs(new arguments(node, args, vararg, kwonlyargs, kw_defaults, kwarg, defaults));
         beginScope(tmp, FUNCSCOPE, node, ac);
         cur.addParam(bound_exp);
         cur.markFromParam();

--- a/src/org/python/core/BaseSet.java
+++ b/src/org/python/core/BaseSet.java
@@ -24,7 +24,7 @@ public abstract class BaseSet extends PyObject implements Set, Traverseproc {
         return _set;
     }
 
-    protected void _update(PyObject data) {
+    public void _update(PyObject data) {
         _update(_set, data);
     }
 

--- a/src/org/python/core/ContextGuard.java
+++ b/src/org/python/core/ContextGuard.java
@@ -62,6 +62,7 @@ public class ContextGuard implements ContextManager {
                 if (pyCode.co_flags.isFlagSet(CodeFlag.CO_GENERATOR)) {
                     return new PyFunction(function.__globals__,
                             function.__defaults__,
+                            function.__kwdefaults__,
                             new ContextCode(pyCode),
                             function.__doc__,
                             (function.__closure__ == null) ? null :

--- a/src/org/python/core/Py.java
+++ b/src/org/python/core/Py.java
@@ -34,8 +34,6 @@ import jnr.posix.util.Platform;
 import org.python.antlr.base.mod;
 import org.python.core.adapter.ClassicPyObjectAdapter;
 import org.python.core.adapter.ExtensiblePyObjectAdapter;
-import org.python.core.Traverseproc;
-import org.python.core.Visitproc;
 import org.python.modules.posix.PosixModule;
 import org.python.util.Generic;
 
@@ -759,11 +757,11 @@ public final class Py {
             boolean args, boolean keywords,
             PyFunctionTable funcs, int func_id,
             String[] cellvars, String[] freevars,
-            int npurecell, int moreflags) {
+            int npurecell, int kwonlyargcount, int moreflags) {
         return new PyTableCode(argcount, varnames,
                 filename, name, 0, args, keywords, funcs,
                 func_id, cellvars, freevars, npurecell,
-                moreflags);
+                kwonlyargcount, moreflags);
     }
 
     public static PyCode newCode(int argcount, String varnames[],
@@ -772,11 +770,11 @@ public final class Py {
             boolean args, boolean keywords,
             PyFunctionTable funcs, int func_id,
             String[] cellvars, String[] freevars,
-            int npurecell, int moreflags) {
+            int npurecell, int kwonlyargcount, int moreflags) {
         return new PyTableCode(argcount, varnames,
                 filename, name, firstlineno, args, keywords,
                 funcs, func_id, cellvars, freevars, npurecell,
-                moreflags);
+                kwonlyargcount, moreflags);
     }
 
     // --
@@ -1835,8 +1833,11 @@ public final class Py {
                                      PyObject[] closure_cells) {
         ThreadState state = getThreadState();
         PyObject dict = code.call(state, Py.EmptyObjects, Py.NoKeywords,
-                state.frame.f_globals, Py.EmptyObjects, new PyTuple(closure_cells));
-        return makeClass(name, bases, dict);
+                state.frame.f_globals, Py.EmptyObjects, new PyDictionary(), new PyTuple(closure_cells));
+        return makeClass(name, bases, dict, metaclass);
+    }
+    public static PyObject makeClass(String name, PyObject base, PyObject dict) {
+        return makeClass(name, base, dict, null);
     }
 
     public static PyObject makeClass(String name, PyObject base, PyObject dict) {
@@ -2372,47 +2373,47 @@ class JavaCode extends PyCode implements Traverseproc {
 
     @Override
     public PyObject call(ThreadState state, PyObject args[], String keywords[],
-            PyObject globals, PyObject[] defaults,
-            PyObject closure) {
+                         PyObject globals, PyObject[] defaults, PyDictionary kw_defaults,
+                         PyObject closure) {
         return func.__call__(args, keywords);
     }
 
     @Override
     public PyObject call(ThreadState state, PyObject self, PyObject args[], String keywords[],
-            PyObject globals, PyObject[] defaults,
-            PyObject closure) {
+                         PyObject globals, PyObject[] defaults, PyDictionary kw_defaults,
+                         PyObject closure) {
         return func.__call__(self, args, keywords);
     }
 
     @Override
     public PyObject call(ThreadState state, PyObject globals, PyObject[] defaults,
-            PyObject closure) {
+                         PyDictionary kw_defaults, PyObject closure) {
         return func.__call__();
     }
 
     @Override
     public PyObject call(ThreadState state, PyObject arg1, PyObject globals,
-            PyObject[] defaults, PyObject closure) {
+                         PyObject[] defaults, PyDictionary kw_defaults, PyObject closure) {
         return func.__call__(arg1);
     }
 
     @Override
     public PyObject call(ThreadState state, PyObject arg1, PyObject arg2, PyObject globals,
-            PyObject[] defaults, PyObject closure) {
+                         PyObject[] defaults, PyDictionary kw_defaults, PyObject closure) {
         return func.__call__(arg1, arg2);
     }
 
     @Override
     public PyObject call(ThreadState state, PyObject arg1, PyObject arg2, PyObject arg3,
-            PyObject globals, PyObject[] defaults,
-            PyObject closure) {
+                         PyObject globals, PyObject[] defaults, PyDictionary kw_defaults,
+                         PyObject closure) {
         return func.__call__(arg1, arg2, arg3);
     }
 
     @Override
     public PyObject call(ThreadState state, PyObject arg1, PyObject arg2,
-            PyObject arg3, PyObject arg4, PyObject globals,
-            PyObject[] defaults, PyObject closure) {
+                         PyObject arg3, PyObject arg4, PyObject globals,
+                         PyObject[] defaults, PyDictionary kw_defaults, PyObject closure) {
         return func.__call__(arg1, arg2, arg3, arg4);
     }
 

--- a/src/org/python/core/PyBaseCode.java
+++ b/src/org/python/core/PyBaseCode.java
@@ -116,7 +116,7 @@ public abstract class PyBaseCode extends PyCode {
     public PyObject call(ThreadState state, PyObject globals, PyObject[] defaults,
                          PyDictionary kw_defaults, PyObject closure)
     {
-        if (co_argcount != 0 || varargs || varkwargs)
+        if (co_argcount != 0 || varargs || varkwargs || !kw_defaults.isEmpty())
             return call(state, Py.EmptyObjects, Py.NoKeywords, globals, defaults,
                         kw_defaults, closure);
         PyFrame frame = new PyFrame(this, globals);
@@ -130,7 +130,7 @@ public abstract class PyBaseCode extends PyCode {
     public PyObject call(ThreadState state, PyObject arg1, PyObject globals, PyObject[] defaults,
                          PyDictionary kw_defaults, PyObject closure)
     {
-        if (co_argcount != 1 || varargs || varkwargs)
+        if (co_argcount != 1 || varargs || varkwargs || !kw_defaults.isEmpty())
             return call(state, new PyObject[] {arg1},
                         Py.NoKeywords, globals, defaults, kw_defaults, closure);
         PyFrame frame = new PyFrame(this, globals);
@@ -145,7 +145,7 @@ public abstract class PyBaseCode extends PyCode {
     public PyObject call(ThreadState state, PyObject arg1, PyObject arg2, PyObject globals,
                          PyObject[] defaults, PyDictionary kw_defaults, PyObject closure)
     {
-        if (co_argcount != 2 || varargs || varkwargs)
+        if (co_argcount != 2 || varargs || varkwargs || !kw_defaults.isEmpty())
             return call(state, new PyObject[] {arg1, arg2},
                         Py.NoKeywords, globals, defaults, kw_defaults, closure);
         PyFrame frame = new PyFrame(this, globals);
@@ -162,7 +162,7 @@ public abstract class PyBaseCode extends PyCode {
                          PyObject globals, PyObject[] defaults, PyDictionary kw_defaults,
                          PyObject closure)
     {
-        if (co_argcount != 3 || varargs || varkwargs)
+        if (co_argcount != 3 || varargs || varkwargs || !kw_defaults.isEmpty())
             return call(state, new PyObject[] {arg1, arg2, arg3},
                         Py.NoKeywords, globals, defaults, kw_defaults, closure);
         PyFrame frame = new PyFrame(this, globals);
@@ -179,7 +179,7 @@ public abstract class PyBaseCode extends PyCode {
     public PyObject call(ThreadState state, PyObject arg1, PyObject arg2,
                          PyObject arg3, PyObject arg4, PyObject globals,
                          PyObject[] defaults, PyDictionary kw_defaults, PyObject closure) {
-        if (co_argcount != 4 || varargs || varkwargs)
+        if (co_argcount != 4 || varargs || varkwargs || !kw_defaults.isEmpty())
             return call(state, new PyObject[]{arg1, arg2, arg3, arg4},
                         Py.NoKeywords, globals, defaults, kw_defaults, closure);
         PyFrame frame = new PyFrame(this, globals);

--- a/src/org/python/core/PyBaseCode.java
+++ b/src/org/python/core/PyBaseCode.java
@@ -4,12 +4,16 @@
  */
 package org.python.core;
 
+import com.google.common.base.Joiner;
 import org.python.modules._systemrestart;
 import com.google.common.base.CharMatcher;
+
+import java.util.ArrayList;
 
 public abstract class PyBaseCode extends PyCode {
 
     public int co_argcount;
+    public int co_kwonlyargcount;
     int nargs;
     public int co_firstlineno = -1;
     public String co_varnames[];
@@ -26,12 +30,11 @@ public abstract class PyBaseCode extends PyCode {
         return co_freevars != null && co_freevars.length > 0;
     }
 
+    @Override
     public PyObject call(ThreadState ts, PyFrame frame, PyObject closure) {
-//         System.err.println("tablecode call: "+co_name);
         if (ts.systemState == null) {
             ts.systemState = Py.defaultSystemState;
         }
-        //System.err.println("got ts: "+ts+", "+ts.systemState);
 
         // Cache previously defined exception
         PyException previous_exception = ts.exception;
@@ -42,8 +45,6 @@ public abstract class PyBaseCode extends PyCode {
             if (frame.f_back != null) {
                 frame.f_builtins = frame.f_back.f_builtins;
             } else {
-                //System.err.println("ts: "+ts);
-                //System.err.println("ss: "+ts.systemState);
                 frame.f_builtins = ts.systemState.builtins;
             }
         }
@@ -111,12 +112,13 @@ public abstract class PyBaseCode extends PyCode {
         return ret;
     }
 
+    @Override
     public PyObject call(ThreadState state, PyObject globals, PyObject[] defaults,
-                         PyObject closure)
+                         PyDictionary kw_defaults, PyObject closure)
     {
         if (co_argcount != 0 || varargs || varkwargs)
             return call(state, Py.EmptyObjects, Py.NoKeywords, globals, defaults,
-                        closure);
+                        kw_defaults, closure);
         PyFrame frame = new PyFrame(this, globals);
         if (co_flags.isFlagSet(CodeFlag.CO_GENERATOR)) {
             return new PyGenerator(frame, closure);
@@ -124,12 +126,13 @@ public abstract class PyBaseCode extends PyCode {
         return call(state, frame, closure);
     }
 
+    @Override
     public PyObject call(ThreadState state, PyObject arg1, PyObject globals, PyObject[] defaults,
-                         PyObject closure)
+                         PyDictionary kw_defaults, PyObject closure)
     {
         if (co_argcount != 1 || varargs || varkwargs)
             return call(state, new PyObject[] {arg1},
-                        Py.NoKeywords, globals, defaults, closure);
+                        Py.NoKeywords, globals, defaults, kw_defaults, closure);
         PyFrame frame = new PyFrame(this, globals);
         frame.f_fastlocals[0] = arg1;
         if (co_flags.isFlagSet(CodeFlag.CO_GENERATOR)) {
@@ -138,12 +141,13 @@ public abstract class PyBaseCode extends PyCode {
         return call(state, frame, closure);
     }
 
+    @Override
     public PyObject call(ThreadState state, PyObject arg1, PyObject arg2, PyObject globals,
-                         PyObject[] defaults, PyObject closure)
+                         PyObject[] defaults, PyDictionary kw_defaults, PyObject closure)
     {
         if (co_argcount != 2 || varargs || varkwargs)
             return call(state, new PyObject[] {arg1, arg2},
-                        Py.NoKeywords, globals, defaults, closure);
+                        Py.NoKeywords, globals, defaults, kw_defaults, closure);
         PyFrame frame = new PyFrame(this, globals);
         frame.f_fastlocals[0] = arg1;
         frame.f_fastlocals[1] = arg2;
@@ -153,13 +157,14 @@ public abstract class PyBaseCode extends PyCode {
         return call(state, frame, closure);
     }
 
+    @Override
     public PyObject call(ThreadState state, PyObject arg1, PyObject arg2, PyObject arg3,
-                         PyObject globals, PyObject[] defaults,
+                         PyObject globals, PyObject[] defaults, PyDictionary kw_defaults,
                          PyObject closure)
     {
         if (co_argcount != 3 || varargs || varkwargs)
             return call(state, new PyObject[] {arg1, arg2, arg3},
-                        Py.NoKeywords, globals, defaults, closure);
+                        Py.NoKeywords, globals, defaults, kw_defaults, closure);
         PyFrame frame = new PyFrame(this, globals);
         frame.f_fastlocals[0] = arg1;
         frame.f_fastlocals[1] = arg2;
@@ -172,11 +177,11 @@ public abstract class PyBaseCode extends PyCode {
     
     @Override
     public PyObject call(ThreadState state, PyObject arg1, PyObject arg2,
-            PyObject arg3, PyObject arg4, PyObject globals,
-            PyObject[] defaults, PyObject closure) {
+                         PyObject arg3, PyObject arg4, PyObject globals,
+                         PyObject[] defaults, PyDictionary kw_defaults, PyObject closure) {
         if (co_argcount != 4 || varargs || varkwargs)
             return call(state, new PyObject[]{arg1, arg2, arg3, arg4},
-                        Py.NoKeywords, globals, defaults, closure);
+                        Py.NoKeywords, globals, defaults, kw_defaults, closure);
         PyFrame frame = new PyFrame(this, globals);
         frame.f_fastlocals[0] = arg1;
         frame.f_fastlocals[1] = arg2;
@@ -188,19 +193,24 @@ public abstract class PyBaseCode extends PyCode {
         return call(state, frame, closure);
     }
 
+    @Override
     public PyObject call(ThreadState state, PyObject self, PyObject args[],
                          String keywords[], PyObject globals,
-                         PyObject[] defaults, PyObject closure)
+                         PyObject[] defaults, PyDictionary kw_defaults, PyObject closure)
     {
         PyObject[] os = new PyObject[args.length+1];
         os[0] = self;
         System.arraycopy(args, 0, os, 1, args.length);
-        return call(state, os, keywords, globals, defaults, closure);
+        return call(state, os, keywords, globals, defaults, kw_defaults, closure);
     }
 
+    @Override
     public PyObject call(ThreadState state, PyObject args[], String kws[], PyObject globals,
-                         PyObject[] defs, PyObject closure) {
+                         PyObject[] defs, PyDictionary kw_defaults, PyObject closure) {
         final PyFrame frame = new PyFrame(this, globals);
+        int paramCount = co_argcount + co_kwonlyargcount;
+        if (varargs) paramCount += 1;
+        if (varkwargs) paramCount += 1;
         final int argcount = args.length - kws.length;
 
         if ((co_argcount > 0) || varargs || varkwargs) {
@@ -235,7 +245,7 @@ public abstract class PyBaseCode extends PyCode {
 
             if (varargs) {
                 PyObject[] u = new PyObject[argcount - n];
-                System.arraycopy(args, n, u, 0, argcount - n);
+                System.arraycopy(args, n, u, 0, u.length);
                 PyObject uTuple = new PyTuple(u);
                 fastlocals[co_argcount] = uTuple;
             }
@@ -243,12 +253,12 @@ public abstract class PyBaseCode extends PyCode {
                 String keyword = kws[i];
                 PyObject value = args[i + argcount];
                 int j;
-                for (j = 0; j < co_argcount; j++) {
+                for (j = 0; j < paramCount; j++) {
                     if (co_varnames[j].equals(keyword)) {
                         break;
                     }
                 }
-                if (j >= co_argcount) {
+                if (j == paramCount) { // not in varnames
                     if (kwdict == null) {
                         throw Py.TypeError(String.format(
                                 "%.200s() got an unexpected keyword argument '%.400s'",
@@ -269,6 +279,27 @@ public abstract class PyBaseCode extends PyCode {
                     fastlocals[j] = value;
                 }
             }
+            java.util.List<String> missingKwArg = new ArrayList<>();
+
+            int kwonlyargZeroIndex = co_argcount;
+            if (varargs) kwonlyargZeroIndex += 1;
+            for (int j = 0; j < co_kwonlyargcount; j++) {
+                int kwonlyargIdx = kwonlyargZeroIndex + j;
+                String name = co_varnames[kwonlyargIdx];
+                PyUnicode key = Py.newUnicode(name);
+                if (fastlocals[kwonlyargIdx] == null) {
+                    if (kw_defaults.__contains__(key)) {
+                        fastlocals[kwonlyargIdx] = kw_defaults.__getitem__(key);
+                    } else {
+                        missingKwArg.add(name);
+                    }
+                }
+            }
+            if (!missingKwArg.isEmpty()) {
+                throw Py.TypeError(String.format("%.200s() missing %d keyword-only %s: %s", co_name, missingKwArg.size(),
+                        missingKwArg.size() > 1 ? "arguments" : "argument", Joiner.on(',').join(missingKwArg)));
+            }
+
             if (argcount < co_argcount) {
                 final int defcount = defs != null ? defs.length : 0;
                 final int m = co_argcount - defcount;

--- a/src/org/python/core/PyBytecode.java
+++ b/src/org/python/core/PyBytecode.java
@@ -1334,8 +1334,8 @@ public class PyBytecode extends PyBaseCode implements Traverseproc {
 
     private static void call_function(int na, int nk, boolean var, boolean kw, PyStack stack) {
         int n = na + nk * 2;
-        PyObject kwargs = kw ? stack.pop() : null;
-        PyObject starargs = var ? stack.pop() : null;
+        PyObject[] kwargs = kw ? new PyObject[]{stack.pop()} : new PyObject[0];
+        PyObject[] starargs = var ? new PyObject[]{stack.pop()} : new PyObject[0];
         PyObject params[] = stack.popN(n);
         PyObject callable = stack.pop();
 

--- a/src/org/python/core/PyBytecode.java
+++ b/src/org/python/core/PyBytecode.java
@@ -85,7 +85,7 @@ public class PyBytecode extends PyBaseCode implements Traverseproc {
         co_lnotab = getBytes(lnotab);
     }
     private static final String[] __members__ = {
-        "co_name", "co_argcount",
+        "co_name", "co_argcount", "co_kwonlyargcount",
         "co_varnames", "co_filename", "co_firstlineno",
         "co_flags", "co_cellvars", "co_freevars", "co_nlocals",
         "co_code", "co_consts", "co_names", "co_lnotab", "co_stacksize"
@@ -1127,12 +1127,13 @@ public class PyBytecode extends PyBaseCode implements Traverseproc {
 
                     case Opcode.MAKE_FUNCTION: {
                         PyCode code = (PyCode) stack.pop();
+                        PyDictionary kw_defaults = (PyDictionary) stack.pop();
                         PyObject[] defaults = stack.popN(oparg);
                         PyObject doc = null;
                         if (code instanceof PyBytecode && ((PyBytecode) code).co_consts.length > 0) {
                             doc = ((PyBytecode) code).co_consts[0];
                         }
-                        PyFunction func = new PyFunction(f.f_globals, defaults, code, doc);
+                        PyFunction func = new PyFunction(f.f_globals, defaults, kw_defaults, code, doc);
                         stack.push(func);
                         break;
                     }
@@ -1140,12 +1141,13 @@ public class PyBytecode extends PyBaseCode implements Traverseproc {
                     case Opcode.MAKE_CLOSURE: {
                         PyCode code = (PyCode) stack.pop();
                         PyObject[] closure_cells = ((PySequenceList) (stack.pop())).getArray();
+                        PyDictionary kw_defaults = (PyDictionary) stack.pop();
                         PyObject[] defaults = stack.popN(oparg);
                         PyObject doc = null;
                         if (code instanceof PyBytecode && ((PyBytecode) code).co_consts.length > 0) {
                             doc = ((PyBytecode) code).co_consts[0];
                         }
-                        PyFunction func = new PyFunction(f.f_globals, defaults, code, doc, closure_cells);
+                        PyFunction func = new PyFunction(f.f_globals, defaults, kw_defaults, code, doc, closure_cells);
                         stack.push(func);
                         break;
                     }

--- a/src/org/python/core/PyCode.java
+++ b/src/org/python/core/PyCode.java
@@ -21,35 +21,36 @@ public abstract class PyCode extends PyObject
     abstract public PyObject call(ThreadState state,
                                   PyObject args[], String keywords[],
                                   PyObject globals, PyObject[] defaults,
-                                  PyObject closure);
+                                  PyDictionary kw_defaults, PyObject closure);
 
     abstract public PyObject call(ThreadState state,
                                   PyObject self, PyObject args[],
                                   String keywords[],
                                   PyObject globals, PyObject[] defaults,
-                                  PyObject closure);
+                                  PyDictionary kw_defaults, PyObject closure);
 
     abstract public PyObject call(ThreadState state,
                                   PyObject globals, PyObject[] defaults,
-                                  PyObject closure);
+                                  PyDictionary kw_defaults, PyObject closure);
 
     abstract public PyObject call(ThreadState state,
                                   PyObject arg1, PyObject globals,
-                                  PyObject[] defaults, PyObject closure);
+                                  PyObject[] defaults,
+                                  PyDictionary kw_defaults, PyObject closure);
 
     abstract public PyObject call(ThreadState state,
                                   PyObject arg1, PyObject arg2,
                                   PyObject globals, PyObject[] defaults,
-                                  PyObject closure);
+                                  PyDictionary kw_defaults, PyObject closure);
 
     abstract public PyObject call(ThreadState state,
                                   PyObject arg1, PyObject arg2, PyObject arg3,
                                   PyObject globals, PyObject[] defaults,
-                                  PyObject closure);
+                                  PyDictionary kw_defaults, PyObject closure);
 
     abstract public PyObject call(ThreadState state,
                                   PyObject arg1, PyObject arg2, PyObject arg3, PyObject arg4,
                                   PyObject globals, PyObject[] defaults,
-                                  PyObject closure);
+                                  PyDictionary kw_defaults, PyObject closure);
 
 }

--- a/src/org/python/core/PyDictionary.java
+++ b/src/org/python/core/PyDictionary.java
@@ -7,6 +7,7 @@ package org.python.core;
 import java.util.AbstractSet;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -63,6 +64,17 @@ public class PyDictionary extends PyObject implements ConcurrentMap, Traversepro
     public PyDictionary(PyType type) {
         super(type);
         internalMap = Generic.concurrentMap();
+    }
+
+    /**
+     * Create a dictionary with keys and values list, used when create keyvalue-only parameter defaults
+     */
+    public PyDictionary(String[] keys, PyObject[] values) {
+        this();
+        ConcurrentMap<PyObject, PyObject> map = getMap();
+        for (int i = 0; i < keys.length; i++) {
+            map.put(Py.newUnicode(keys[i]), values[i]);
+        }
     }
 
     /**

--- a/src/org/python/core/PyDictionary.java
+++ b/src/org/python/core/PyDictionary.java
@@ -442,7 +442,7 @@ public class PyDictionary extends PyObject implements ConcurrentMap, Traversepro
      *
      * @param other a PyObject with a keys() method
      */
-    private void merge(PyObject other) {
+    public void merge(PyObject other) {
         if (other instanceof PyDictionary) {
             getMap().putAll(((PyDictionary) other).getMap());
         } else if (other instanceof PyStringMap) {

--- a/src/org/python/core/PyObject.java
+++ b/src/org/python/core/PyObject.java
@@ -523,8 +523,8 @@ public class PyObject implements Serializable {
 
     public PyObject _callextra(PyObject[] args,
                                String[] keywords,
-                               PyObject starargs,
-                               PyObject kwargs) {
+                               PyObject[] starargsArray,
+                               PyObject[] kwargsArray) {
 
         int argslen = args.length;
 
@@ -536,7 +536,7 @@ public class PyObject implements Serializable {
         } else {
             name = getType().fastGetName() + " ";
         }
-        if (kwargs != null) {
+        for (PyObject kwargs : kwargsArray) {
             PyObject keys = kwargs.__findattr__("keys");
             if(keys == null)
                 throw Py.TypeError(name
@@ -552,7 +552,7 @@ public class PyObject implements Serializable {
             argslen += kwargs.__len__();
         }
         List<PyObject> starObjs = null;
-        if (starargs != null) {
+        for (PyObject starargs : starargsArray) {
             starObjs = new ArrayList<PyObject>();
             PyObject iter = Py.iter(starargs, name + "argument after * must be a sequence");
             for (PyObject cur = null; ((cur = iter.__iternext__()) != null); ) {
@@ -576,7 +576,7 @@ public class PyObject implements Serializable {
                          keywords.length);
         argidx += keywords.length;
 
-        if (kwargs != null) {
+        for (PyObject kwargs : kwargsArray) {
             String[] newkeywords =
                 new String[keywords.length + kwargs.__len__()];
             System.arraycopy(keywords, 0, newkeywords, 0, keywords.length);

--- a/src/org/python/indexer/AstConverter.java
+++ b/src/org/python/indexer/AstConverter.java
@@ -385,8 +385,8 @@ public class AstConverter extends Visitor {
         return new NCall(convExpr(n.getInternalFunc()),
                          convertListExpr(n.getInternalArgs()),
                          convertListKeyword(n.getInternalKeywords()),
-                         convExpr(n.getInternalKwargs()),
-                         convExpr(n.getInternalStarargs()),
+                         null,
+                         null,
                          start(n), stop(n));
     }
 


### PR DESCRIPTION
support following unpacking style:

```python
>>> dict(**{'x': 1}, y=2, **{'z': 3})
{'x': 1, 'y': 2, 'z': 3}
>>> {**{'x': 2}, 'x': 1}
{'x': 1}
```

Added keyword only arguments (PEP-3102)

```python
def foo(x, *y, z=1):
   pass

def bar(a, *, b):
  pass
```