### PR TITLE
Ensure error reported when a codec cannot be found for the console

### DIFF
--- a/src/org/python/core/PyException.java
+++ b/src/org/python/core/PyException.java
@@ -3,7 +3,7 @@ package org.python.core;
 import java.io.*;
 
 /**
- * A wrapper for all python exception. Note that the well-known python Exceptions are <b>not</b>
+ * A wrapper for all python exception. Note that the well-known python exceptions are <b>not</b>
  * subclasses of PyException. Instead the python exception class is stored in the <code>type</code>
  * field and value or class instance is stored in the <code>value</code> field.
  */
@@ -94,14 +94,17 @@ public class PyException extends RuntimeException implements Traverseproc
     }
 
     private boolean printingStackTrace = false;
+    @Override
     public void printStackTrace() {
         Py.printException(this);
     }
 
+    @Override
     public Throwable fillInStackTrace() {
         return Options.includeJavaStackInExceptions ? super.fillInStackTrace() : this;
     }
 
+    @Override
     public synchronized void printStackTrace(PrintStream s) {
         if (printingStackTrace) {
             super.printStackTrace(s);
@@ -124,12 +127,9 @@ public class PyException extends RuntimeException implements Traverseproc
         }
     }
 
+    @Override
     public synchronized String toString() {
-        ByteArrayOutputStream buf = new ByteArrayOutputStream();
-        if (!printingStackTrace) {
-            printStackTrace(new PrintStream(buf));
-        }
-        return buf.toString();
+        return Py.exceptionToString(type, value, traceback);
     }
 
     /**
@@ -357,10 +357,11 @@ public class PyException extends RuntimeException implements Traverseproc
     public static String exceptionClassName(PyObject obj) {
         return ((PyType)obj).fastGetName();
     }
-    
-    
+
+
     /* Traverseproc support */
 
+    @Override
     public int traverse(Visitproc visit, Object arg) {
         int retValue;
         if (type != null) {
@@ -382,6 +383,7 @@ public class PyException extends RuntimeException implements Traverseproc
         return 0;
     }
 
+    @Override
     public boolean refersDirectlyTo(PyObject ob) {
     	return ob != null && (type == ob || value == ob || traceback == ob);
     }


### PR DESCRIPTION
Adds a change to fall back on ascii & System.err when displaying an exception fails.

Our mechanism for displaying an exception and stack trace relies on a
codec being available for the console. This change adapts code from
Jython 2.7.1 that gives us a second chance to output an exception that
tells us what's really going wrong.

On Windows, I now get this kind of result:
```
> dist\bin\jython -S
Jython 3.5.1a1+ (, Jun 4 2017, 09:03:19)
[Java HotSpot(TM) 64-Bit Server VM (Oracle Corporation)] on java1.8.0_131
Py.displayException failed. Falling back to System.err.
Traceback (most recent call last):
  File "_bootstrap_external.py", line 1101, in _path_importer_cache
KeyError: C:\Users\Jeff\Documents\Eclipse\Jython-3

Exception in thread "main" LookupError: no codec search functions registered: can't find encoding 'cp850'

> dist\bin\jython
Exception in thread "main" Py.displayException failed. Falling back to System.err.
Traceback (most recent call last):
  File "_bootstrap.py", line 969, in _find_and_load
  File "_bootstrap.py", line 969, in _find_and_load
  File "_bootstrap.py", line 969, in _find_and_load
  File "_bootstrap.py", line 954, in _find_and_load_unlocked
  File "_bootstrap.py", line 896, in _find_spec
  File "_bootstrap.py", line 896, in _find_spec
  File "_bootstrap.py", line 896, in _find_spec
  File "_bootstrap_external.py", line 1160, in find_spec
  File "_bootstrap_external.py", line 1131, in _get_spec
  File "_bootstrap_external.py", line 1103, in _path_importer_cache
  File "_bootstrap_external.py", line 1079, in _path_hooks
  File "_bootstrap_external.py", line 1079, in _path_hooks
TypeError: org.python.modules.zipimport.PyZipImporter(): 1st arg can't be coerced to org.python.core.PyType
```