### PR TITLE
Fix problems with import and zipimport in particular 

### DIFF
--- a/src/org/python/modules/zipimport/ZipImportModule.java
+++ b/src/org/python/modules/zipimport/ZipImportModule.java
@@ -1,20 +1,18 @@
-/* Copyright (c) 2007 Jython Developers */
+/* Copyright (c) 2017 Jython Developers */
 package org.python.modules.zipimport;
 
 import org.python.core.BuiltinDocs;
-import org.python.core.ClassDictInit;
 import org.python.core.Py;
 import org.python.core.PyDictionary;
 import org.python.core.PyException;
 import org.python.core.PyObject;
-import org.python.core.PyBytes;
 import org.python.core.PyStringMap;
 import org.python.expose.ExposedModule;
 import org.python.expose.ModuleInit;
 
 /**
- * This module adds the ability to import Python modules (*.py,
- * *$py.class) and packages from ZIP-format archives.
+ * This module adds the ability to import Python modules (<code>*.py</code>,
+ * <code>*$py.class</code>) and packages from ZIP-format archives.
  *
  * @author Philip Jenvey
  */
@@ -22,11 +20,13 @@ import org.python.expose.ModuleInit;
 public class ZipImportModule {
 
     public static PyObject ZipImportError;
+
     public static PyException ZipImportError(String message) {
         return new PyException(ZipImportError, message);
     }
 
-    // FIXME this cache should be per PySystemState, but at the very least it should also be weakly referenced!
+    // FIXME this cache should be per PySystemState, but at the very least it should also be weakly
+    // referenced!
     // FIXME could also do this via a loading cache instead
     public static PyDictionary _zip_directory_cache = new PyDictionary();
 
@@ -37,15 +37,15 @@ public class ZipImportModule {
         dict.__setitem__("ZipImportError", ZipImportError);
     }
 
-    /**
-     * Initialize the ZipImportError exception during startup
-     *
-     */
+    /** Initialize the ZipImportError exception during startup */
     public static void initClassExceptions(PyObject exceptions) {
         PyObject ImportError = exceptions.__finditem__("ImportError");
-        ZipImportError = Py.makeClass("zipimport.ZipImportError", ImportError,
-                                      new PyStringMap() {{
-                                          __setitem__("__module__", Py.newString("zipimport"));
-                                      }});
+
+        ZipImportError = Py.makeClass("zipimport.ZipImportError", ImportError, new PyStringMap() {
+
+            {
+                __setitem__("__module__", Py.newString("zipimport"));
+            }
+        });
     }
 }


### PR DESCRIPTION
Beginning work on the failure that happens on startup of Jython. First commit is just whitespace and comment. The actual problem is that the constructor has 3 args, but is called (correctly) with just the archive path.

I can fix this by moving some path-wrangling from __init__ into a one-arg constructor. However, shouldn't __init__ be called rather than the constructor by reflection? But that's what's on sys.path_hooks. 