### PR TITLE
Travis CI: Find Python 3 syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,22 @@ os:
 
 script: ant && ant regrtest
 
+
+matrix:
+  allow_failures:
+    - python: 3.7
+  include:
+    - python: 3.7
+      language: python
+      cache: pip
+      dist: xenial  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+      install:
+        # - pip install -r requirements.txt
+        - pip install flake8
+      before_script:
+        # stop the build if there are Python syntax errors or undefined names
+        - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+        - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      script:
+        - true  # add other tests here


### PR DESCRIPTION
Unfortunately, Travis CI is not turned on for this repo.  https://travis-ci.org/jython